### PR TITLE
fix(deps): move source-map-support to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "ses": "^1.10.0",
+        "source-map-support": "^0.5.21",
         "three": "^0.170.0",
         "three-mesh-bvh": "^0.8.3"
       },
@@ -45,8 +46,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react": "^7.34.0",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "prettier": "^3.4.2",
-        "source-map-support": "^0.5.21"
+        "prettier": "^3.4.2"
       },
       "engines": {
         "node": "22.11.0",
@@ -6191,7 +6191,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6201,7 +6200,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "react-dom": "^18.3.1",
     "ses": "^1.10.0",
     "three": "^0.170.0",
-    "three-mesh-bvh": "^0.8.3"
+    "three-mesh-bvh": "^0.8.3",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "eslint": "^8.57.0",
@@ -63,8 +64,7 @@
     "@babel/eslint-parser": "^7.23.10",
     "@babel/preset-react": "^7.23.10",
     "esbuild": "^0.24.0",
-    "prettier": "^3.4.2",
-    "source-map-support": "^0.5.21"
+    "prettier": "^3.4.2"
   },
   "engines": {
     "npm": ">=10.0.0",


### PR DESCRIPTION
## Description

Fix production deployment by moving `source-map-support` from devDependencies to dependencies in package.json. This package is required at runtime for proper stack trace support in the server environment.

The change ensures that source maps work correctly in production, improving error debugging capabilities.

Fixes: Server startup errors in production due to missing source-map-support dependency
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes a component issue)

## How Has This Been Tested?

- [x] Component functionality tests
  - Verified server starts correctly with production dependencies
  - Confirmed source maps are generated and working
  - Tested error stack traces in production environment
- [x] World integration testing
  - Tested server startup in production mode
  - Verified error reporting works as expected
- [x] Cross-browser testing
  - Tested error reporting in Chrome and Firefox

**Test Configuration**:
* Hyperfy Version: 0.1.0
* Test world setup: Clean installation with production dependencies
* Browser(s): Chrome 131.0.6778.265
* Node.js version: 22.11.0

## Checklist:

- [x] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [x] I have documented the component's usage
- [x] I have tested the component in multiple scenarios
- [x] My changes maintain compatibility with existing worlds
- [x] I have updated the component documentation if needed
