### PR TITLE
Feat: Persist pos/scale of chosen panes, clamp panes on screen

### DIFF
--- a/src/client/components/CodePane.js
+++ b/src/client/components/CodePane.js
@@ -84,6 +84,8 @@ export function CodePane({ entity, onClose }) {
         box-shadow: rgba(0, 0, 0, 0.5) 0px 10px 30px;
         pointer-events: auto;
         display: flex;
+        resize: both;
+        overflow: auto;
         flex-direction: column;
         .acode-head {
           height: 40px;

--- a/src/client/components/usePane.js
+++ b/src/client/components/usePane.js
@@ -1,9 +1,43 @@
 import { useEffect } from 'react'
 
-const configs = {}
-
+const STORAGE_KEY = 'pane_configs'
+const WHITELISTED_IDS = ['code'] // Add your whitelisted IDs here
+let configs = {}
 let count = 0
 let layer = 0
+
+// Load saved configs from localStorage only for whitelisted IDs
+try {
+  const savedConfigs = localStorage.getItem(STORAGE_KEY)
+  if (savedConfigs) {
+    const parsedConfigs = JSON.parse(savedConfigs)
+    // Only load whitelisted configs
+    configs = Object.keys(parsedConfigs)
+      .filter(key => WHITELISTED_IDS.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = parsedConfigs[key]
+        return obj
+      }, {})
+  }
+} catch (error) {
+  console.error('Error loading pane configs:', error)
+}
+
+// Save configs to localStorage (only whitelisted)
+const saveConfigs = () => {
+  try {
+    // Only save whitelisted configs
+    const configsToSave = Object.keys(configs)
+      .filter(key => WHITELISTED_IDS.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = configs[key]
+        return obj
+      }, {})
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(configsToSave))
+  } catch (error) {
+    console.error('Error saving pane configs:', error)
+  }
+}
 
 export function usePane(id, paneRef, headRef) {
   useEffect(() => {
@@ -13,42 +47,85 @@ export function usePane(id, paneRef, headRef) {
       config = {
         y: count * 20,
         x: count * 20,
+        width: paneRef.current.offsetWidth,
+        height: paneRef.current.offsetHeight,
         layer: 0,
       }
       configs[id] = config
+      if (WHITELISTED_IDS.includes(id)) {
+        saveConfigs()
+      }
     }
+
     layer++
     const pane = paneRef.current
     pane.style.top = `${config.y}px`
     pane.style.left = `${config.x}px`
+    pane.style.width = `${config.width}px`
+    pane.style.height = `${config.height}px`
     pane.style.zIndex = `${layer}`
+
     const head = headRef.current
+
     const onPanePointerDown = () => {
       layer++
       pane.style.zIndex = `${layer}`
     }
-    let moving
+
+    let moving = false
     const onHeadPointerDown = e => {
       moving = true
     }
+
     const onPointerMove = e => {
       if (!moving) return
-      config.x += e.movementX
-      config.y += e.movementY
+
+      // Calculate new position
+      const newX = config.x + e.movementX
+      const newY = config.y + e.movementY
+
+      // Get window dimensions
+      const maxX = window.innerWidth - pane.offsetWidth
+      const maxY = window.innerHeight - pane.offsetHeight
+
+      // Clamp coordinates to keep window visible
+      config.x = Math.min(Math.max(0, newX), maxX)
+      config.y = Math.min(Math.max(0, newY), maxY)
+
       pane.style.top = `${config.y}px`
       pane.style.left = `${config.x}px`
+      if (WHITELISTED_IDS.includes(id)) {
+        saveConfigs()
+      }
     }
+
     const onPointerUp = e => {
       moving = false
     }
+
+    const onResize = new ResizeObserver(entries => {
+      const entry = entries[0]
+      if (entry) {
+        config.width = entry.contentRect.width
+        config.height = entry.contentRect.height
+        if (WHITELISTED_IDS.includes(id)) {
+          saveConfigs()
+        }
+      }
+    })
+
     head.addEventListener('pointerdown', onHeadPointerDown)
     pane.addEventListener('pointerdown', onPanePointerDown)
     window.addEventListener('pointermove', onPointerMove)
     window.addEventListener('pointerup', onPointerUp)
+    onResize.observe(pane)
+
     return () => {
       head.removeEventListener('pointerdown', onHeadPointerDown)
+      pane.removeEventListener('pointerdown', onPanePointerDown)
       window.removeEventListener('pointermove', onPointerMove)
       window.removeEventListener('pointerup', onPointerUp)
+      onResize.disconnect()
     }
   }, [])
 }


### PR DESCRIPTION
## Description

Modified usePane to persist position and scale of pane for whitelisted IDs. their dimensions are stored in localstorage per ID. panes clamp to edge of screen.

## Type of change

- [x] Component enhancement

## How Has This Been Tested?

Please describe your tests:

- [x] Component functionality tests

**Test Configuration**:
* Hyperfy Version: 0.1.0
* Test world setup: drone app
* Browser(s): arc
* Node.js version: 23.5.0

## Checklist:

- [x] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [x] I have documented the component's usage
- [x] I have tested the component in multiple scenarios
- [x] My changes maintain compatibility with existing worlds
- [x] I have updated the component documentation if needed
