### PR TITLE
Fix agent script pane crashing

### DIFF
--- a/src/client/components/InspectPane.js
+++ b/src/client/components/InspectPane.js
@@ -480,7 +480,7 @@ function FieldFile({ world, field, value, modify }) {
   const nRef = useRef(0)
   const update = useUpdate()
   const [loading, setLoading] = useState(null)
-  const kind = kinds[field.kind]
+  const kind = kinds[field.kind] || kinds.model
   const set = async e => {
     // trigger input rebuild
     const n = ++nRef.current


### PR DESCRIPTION
## Description

[feat: add app preload toggle + cleanup pane lifecycle and asset types](https://github.com/hyperfy-xyz/hyperfy/commit/961fe7c4fa1c608dd4da4d9a7a8b56b13b56000d) edits made it so that if you open the script pane for the agent app, it crashes.

Claude summary:
```
Looking at the error and code changes, there's an issue in the FieldFile component related to accessing properties of undefined. The error occurs when clicking 'inspect', specifically:
TypeError: Cannot read properties of undefined (reading 'accept')
The problem stems from changes in how file types are handled. The code diff shows a new kinds object that defines acceptable file types and their properties. The error occurs because field.kind is missing or invalid, so kinds[field.kind] returns undefined.
Here's the key change needed in the FieldFile component:
javascriptCopyconst kind = kinds[field.kind] || kinds.model; // Provide fallback
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes a component issue)

## How Has This Been Tested?

Please describe your tests:

- [x] World integration testing

**Test Configuration**:
* Hyperfy Version: current
* Test world setup: agent script + eliza model
* Browser(s): chrome
* Node.js version: 22.11.0

## Checklist:

- [x] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [x] I have documented the component's usage
- [x] I have tested the component in multiple scenarios
- [x] My changes maintain compatibility with existing worlds
- [ ] I have updated the component documentation if needed
