### PR TITLE
fix: smaller Docker image, and handling signals

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ world
 .git
 .gitignore
 .env.*
+!.env.example
 *.md
 .eslintrc
 .prettierrc

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Build docker image
+
+on:
+  push:
+    branches:
+      - "main"
+      - "dev"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.4
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{github.repository}}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=long
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_HASH=${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,10 +14,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.4
-      - name: Extract branch name
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: extract_branch
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:22 AS build
 
 # Set the working directory
 WORKDIR /app
-
 # Copy package.json and package-lock.json
 COPY package.json package-lock.json ./
 
@@ -12,27 +11,10 @@ RUN npm install
 # Copy the rest of the application code
 COPY . .
 
-# Build the application
-RUN npm run build; exit 0
-
-# Stage 2: Run
-FROM node:22
-
-# Set the working directory
-WORKDIR /app
-
-# Copy the build folder from the previous stage
-COPY --from=build /app/build ./build
-COPY ./src ./src
-
-# Copy package.json and package-lock.json
-COPY package.json package-lock.json ./
-
-# Install only production dependencies
-RUN npm install --only=production
+COPY .env.example .env
 
 # Expose the port the app runs on
 EXPOSE 3000
 
 # Start the application
-CMD ["npm", "run", "start"]
+CMD [ "npm", "run", "prod" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ COPY . .
 
 COPY .env.example .env
 
+ARG COMMIT_HASH=local
+ENV COMMIT_HASH=${COMMIT_HASH:-local}
+
 # Expose the port the app runs on
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN npm install
 
 # Copy the rest of the application code
 COPY . .
-
 COPY .env.example .env
+
+RUN npm run build || exit 0
 
 ARG COMMIT_HASH=local
 ENV COMMIT_HASH=${COMMIT_HASH:-local}
@@ -20,4 +21,4 @@ ENV COMMIT_HASH=${COMMIT_HASH:-local}
 EXPOSE 3000
 
 # Start the application
-CMD [ "npm", "run", "prod" ]
+CMD [ "npm", "run", "start" ]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "dev": "node build.mjs --dev",
     "build": "node build.mjs",
     "start": "node build/index.js",
-    "prod": "npm run build; npm run start",
     "lint": "eslint . --ext .js,.jsx",
     "lint:fix": "eslint . --ext .js,.jsx --fix",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dev": "node build.mjs --dev",
     "build": "node build.mjs",
     "start": "node build/index.js",
+    "prod": "npm run build; npm run start",
     "lint": "eslint . --ext .js,.jsx",
     "lint:fix": "eslint . --ext .js,.jsx --fix",
     "format": "prettier --write .",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -168,3 +168,16 @@ async function worldNetwork(fastify) {
 }
 
 console.log(`running on port ${port}`)
+
+// Graceful shutdown
+process.on('SIGINT', async () => {
+  console.log('SIGINT signal received.')
+  await fastify.close()
+  process.exit(0)
+})
+
+process.on('SIGTERM', async () => {
+  console.log('SIGTERM signal received.')
+  await fastify.close()
+  process.exit(0)
+})

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -128,7 +128,8 @@ fastify.get('/status', async (request, reply) => {
     const status = {
       uptime: Math.round(world.time),
       protected: process.env.ADMIN_CODE !== undefined ? true : false,
-      connectedUsers: []
+      connectedUsers: [],
+      COMMIT_HASH: process.env.COMMIT_HASH,
     }
     for (const socket of world.network.sockets.values()) {  
       status.connectedUsers.push({

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -129,7 +129,7 @@ fastify.get('/status', async (request, reply) => {
       uptime: Math.round(world.time),
       protected: process.env.ADMIN_CODE !== undefined ? true : false,
       connectedUsers: [],
-      COMMIT_HASH: process.env.COMMIT_HASH,
+      commitHash: process.env.COMMIT_HASH,
     }
     for (const socket of world.network.sockets.values()) {  
       status.connectedUsers.push({
@@ -172,13 +172,11 @@ console.log(`running on port ${port}`)
 
 // Graceful shutdown
 process.on('SIGINT', async () => {
-  console.log('SIGINT signal received.')
   await fastify.close()
   process.exit(0)
 })
 
 process.on('SIGTERM', async () => {
-  console.log('SIGTERM signal received.')
   await fastify.close()
   process.exit(0)
 })


### PR DESCRIPTION
- Reduce the docker image from 1.3GB to less than 400MB
- Run build and run script on start to allow changing .env without rebuilding the whole image
- Add signals handling on the server to handle CTRL+C when running in Docker