### PR TITLE
fix: use URL pathname to avoid name issue cause url query params

### DIFF
--- a/src/core/systems/ClientEditor.js
+++ b/src/core/systems/ClientEditor.js
@@ -239,7 +239,7 @@ export class ClientEditor extends System {
         if (url.startsWith('http')) { // Basic URL validation
           const resp = await fetch(url)
           const blob = await resp.blob()
-          file = new File([blob], url.split('/').pop(), { type: resp.headers.get('content-type') })
+          file = new File([blob], new URL(url).pathname.split('/').pop(), { type: resp.headers.get('content-type') })
         }
       }
     } else if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {


### PR DESCRIPTION
When the url had query params (ex: `https://example.com/app.hyp?version=123`), the filename returned as `app.hyp?version=123` and the extension was returned as `hyp?version=123`, making it the condition fail to see the file as .hyp