### PR TITLE
invert zoom for mac

### DIFF
--- a/src/core/systems/ClientControls.js
+++ b/src/core/systems/ClientControls.js
@@ -312,7 +312,7 @@ export class ClientControls extends System {
   onScroll = e => {
     e.preventDefault()
     let delta = e.shiftKey ? e.deltaX : e.deltaY
-    if (!this.isMac) delta = -delta
+    if (this.isMac) delta = -delta
     this.scroll.delta += delta
   }
 


### PR DESCRIPTION
## Description

This feels much more natural on trackpad. Basically reverting it to how v1 felt and I think is most common. i.e. in world of warcraft.

Fixes # (issue)

## Type of change

- [ ] Component enhancement

## How Has This Been Tested?

Please describe your tests:

- [ ] Component functionality tests

**Test Configuration**:
* Hyperfy Version: v0.6.0
* Test world setup: empty world
* Browser(s): arc mac
* Node.js version: 22.11.0

## Checklist:

- [ ] My code follows Hyperfy's component architecture
- [ ] I have performed a self-review
- [ ] I have documented the component's usage
- [ ] I have tested the component in multiple scenarios
- [ ] My changes maintain compatibility with existing worlds
- [ ] I have updated the component documentation if needed
