### PR TITLE
Render controllers when in VR

### DIFF
--- a/src/core/extras/three.js
+++ b/src/core/extras/three.js
@@ -3,6 +3,7 @@ import { computeBoundsTree, disposeBoundsTree, acceleratedRaycast } from 'three-
 import * as THREE from 'three'
 
 export * from 'three'
+export * from 'three/addons'
 
 // override THREE.Vector3 with ours to support _onChange
 export { Vector3Enhanced as Vector3 } from './Vector3Enhanced'

--- a/src/core/systems/XR.js
+++ b/src/core/systems/XR.js
@@ -18,9 +18,12 @@ export class XR extends System {
     super(world)
     this.session = null
     this.camera = null
+    this.controller1Model = null
+    this.controller2Model = null
     this.yOrientation = new THREE.Quaternion()
     this.supportsVR = false
     this.supportsAR = false
+    this.controllerModelFactory = new THREE.XRControllerModelFactory()
   }
 
   async init() {
@@ -45,6 +48,14 @@ export class XR extends System {
     this.session = session
     this.camera = this.world.graphics.renderer.xr.getCamera()
     this.world.emit('xrSession', session)
+
+    this.controller1Model = this.world.graphics.renderer.xr.getControllerGrip(0)
+    this.controller1Model.add(this.controllerModelFactory.createControllerModel(this.controller1Model))
+    this.world.rig.add(this.controller1Model)
+
+    this.controller2Model = this.world.graphics.renderer.xr.getControllerGrip(1)
+    this.controller2Model.add(this.controllerModelFactory.createControllerModel(this.controller2Model))
+    this.world.rig.add(this.controller2Model)
   }
 
   onSessionEnd = () => {
@@ -52,8 +63,12 @@ export class XR extends System {
     this.world.nametags.setOrientation(this.world.rig.quaternion)
     this.world.camera.position.set(0, 0, 0)
     this.world.camera.rotation.set(0, 0, 0)
+    this.world.rig.remove(this.controller1Model)
+    this.world.rig.remove(this.controller2Model)
     this.session = null
     this.camera = null
+    this.controller1Model = null
+    this.controller2Model = null
     this.world.emit('xrSession', null)
   }
 }


### PR DESCRIPTION
## Description

This uses three's XRControllerModelFactory to render the controllers for the user's device when in VR.

## Type of change

- [x] Component enhancement

## How Has This Been Tested?

Please describe your tests:

- [ ] Component functionality tests
- [ ] Integration tests with other Hyperfy components
- [ ] World integration testing
- [ ] Cross-browser testing

**Test Configuration**:
* Hyperfy Version:
* Test world setup:
* Browser(s):
* Node.js version:

## Checklist:

- [x] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [x] I have tested the component in multiple scenarios
- [x] My changes maintain compatibility with existing worlds
