### PR TITLE
fix: user id on chat instead of entity id

### DIFF
--- a/src/client/components/GUI.js
+++ b/src/client/components/GUI.js
@@ -148,7 +148,7 @@ function Side({ world, player, toggleSettings, toggleApps }) {
     const data = {
       id: uuid(),
       from: player.data.user.name,
-      fromId: player.data.id,
+      fromId: player.data.user.id,
       body: msg,
       createdAt: moment().toISOString(),
     }


### PR DESCRIPTION
## Description

chat events from users are sending entityId. this is confusing because in everywhere else we use playerId
![image](https://github.com/user-attachments/assets/2f6d24fe-49ab-4967-b82d-5d14d2f9d4b6)

## Type of change

- [x] Bug fix (non-breaking change which fixes a component issue)

## How Has This Been Tested?

Please describe your tests:
ive used the same app as above and thats the result

![image](https://github.com/user-attachments/assets/b66f9aef-af63-43ea-8c06-1c1b160a57ab)

## Checklist:

- [x] I have performed a self-review
- [x] I have tested the component in multiple scenarios
- [?] My changes maintain compatibility with existing worlds
