### PR TITLE
add command to clear chat server side

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,3 +20,7 @@ Resets the spawn point back to origin. Requires admin role.
 
 Sets your name.
 This is currently the only way to change your name, until the UI for it is built.
+
+### `/chat clear`
+
+Clears all chat messages. Requires admin privledges to use. 

--- a/src/client/components/GUI.js
+++ b/src/client/components/GUI.js
@@ -311,7 +311,7 @@ function Messages({ world, active, touch }) {
   const [msgs, setMsgs] = useState([])
   useEffect(() => {
     return world.chat.subscribe(setMsgs)
-  }, [])
+}, [])
   useEffect(() => {
     let timerId
     const updateNow = () => {

--- a/src/core/packets.js
+++ b/src/core/packets.js
@@ -6,6 +6,7 @@ const packr = new Packr({ structuredClone: true })
 const names = [
   'snapshot',
   'chatAdded',
+  'chatCleared',
   'blueprintAdded',
   'blueprintModified',
   'entityAdded',

--- a/src/core/systems/Chat.js
+++ b/src/core/systems/Chat.js
@@ -38,8 +38,19 @@ export class Chat extends System {
     }
     const readOnly = Object.freeze({ ...msg })
     this.world.events.emit('chat', readOnly)
+
   }
 
+  clear(broadcast) {
+    this.msgs = [];
+    for (const callback of this.listeners) {
+      callback(this.msgs)
+    }
+    if (broadcast) {
+      this.world.network.send('chatCleared')
+    }
+  }
+  
   serialize() {
     return this.msgs
   }

--- a/src/core/systems/ClientNetwork.js
+++ b/src/core/systems/ClientNetwork.js
@@ -98,6 +98,9 @@ export class ClientNetwork extends System {
   onChatAdded = msg => {
     this.world.chat.add(msg, false)
   }
+  onChatCleared = () => {
+    this.world.chat.clear()
+  }
 
   onBlueprintAdded = blueprint => {
     this.world.blueprints.add(blueprint)

--- a/src/core/systems/ServerNetwork.js
+++ b/src/core/systems/ServerNetwork.js
@@ -316,6 +316,17 @@ export class ServerNetwork extends System {
             value: data,
           })
       }
+      if (cmd === 'chat') {
+        const code = arg1
+        if (code !== 'clear') return
+        const player = socket.player
+        const user = player.data.user
+        if (!hasRole(user.roles, 'admin')) {
+          return
+        }
+        this.world.chat.clear(true)
+        return
+      }
       return
     }
     // handle chat messages


### PR DESCRIPTION
## Description
Added basis for clearing chat with admin gated command. Having issues clearing client GUI without browser refresh.
- Added temporary debugging log statements to GUI.js, need to be removed before merge
- added clear() to Chat.js
- listening for clear command in ServerNetwork.js

Cant figure out how to notify client subscribers of server change to message array.

## Type of change

- [ ] Bug fix (non-breaking change which fixes a component issue)
- [ ] New component
- [x] Component enhancement
- [ ] Breaking change (would cause existing worlds using this component to behave differently)
- [ ] Documentation update

## How Has This Been Tested?

Please describe your tests:

- [x] Component functionality tests
- [ ] Integration tests with other Hyperfy components
- [ ] World integration testing
- [x] Cross-browser testing

**Test Configuration**:
* Hyperfy Version: V0.7.0
* Test world setup: local
* Browser(s): chrome
* Node.js version: 22.14.0

## Checklist:

- [x] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [x] I have documented the component's usage
- [X] I have tested the component in multiple scenarios
- [X] My changes maintain compatibility with existing worlds
