### PR TITLE
Changed to relative urls in .env to support localhost and cloudflare tunnels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,10 @@ SAVE_INTERVAL=60
 PUBLIC_MAX_UPLOAD_SIZE=12
 
 # The public web socket url the client connects to
-PUBLIC_WS_URL=ws://localhost:3000/ws
+PUBLIC_WS_URL=/ws
 
 # The public url used by clients to access api (eg upload assets)
-PUBLIC_API_URL=http://localhost:3000/api
+PUBLIC_API_URL=/api
 
 # The public url used by clients to fetch assets
-PUBLIC_ASSETS_URL=http://localhost:3000/assets
+PUBLIC_ASSETS_URL=/assets


### PR DESCRIPTION
## Description

Changed the urls in the .env to be relative. This allows cloudflare tunnels to be used to access the local installation. This is useful when trying to dev using a VR headset.

With this config a dev can either hit http://localhost:3000 (dev machine) or spin up a cloudflare tunnel and then hit that url (e.g. https://hyperfy.example.com (on Quest 3).

Example cloudflare tunnel config:
```
tunnel: hyperfy
credentials-file: /Users/xxx/.cloudflared/1234c567-8a90-1234-bc56-78d9e0123a4bc.json

ingress:
  - hostname: hyperfy.example.com
    service: http://localhost:3000
  - service: http_status:404
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Component enhancement

## How Has This Been Tested?

Functional testing on Quest 3 and desktop browsers.

Please describe your tests:

- [x] Cross-browser testing

**Test Configuration**:
* Hyperfy Version: 0.8.1 / dev
* Test world setup:
* Browser(s): Brave, Safari, Quest Browser
* Node.js version: 22.11.0

## Checklist:

- [ ] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [ ] I have documented the component's usage
- [ ] I have tested the component in multiple scenarios
- [x] My changes maintain compatibility with existing worlds
- [ ] I have updated the component documentation if needed
