### PR TITLE
pass player zoom to script

### DIFF
--- a/src/core/entities/PlayerLocal.js
+++ b/src/core/entities/PlayerLocal.js
@@ -130,6 +130,7 @@ export class PlayerLocal extends Entity {
     this.base.activate({ world: this.world, entity: this })
 
     this.camHeight = DEFAULT_CAM_HEIGHT
+    this.zoomEnabled = true
 
     this.applyAvatar()
 
@@ -671,7 +672,7 @@ export class PlayerLocal extends Entity {
     }
 
     // zoom camera if scrolling wheel
-    if (!isXR) {
+    if (!isXR && this.zoomEnabled) {
       this.cam.zoom += -this.control.scrollDelta.value * ZOOM_SPEED * delta
       this.cam.zoom = clamp(this.cam.zoom, MIN_ZOOM, MAX_ZOOM)
     }
@@ -912,6 +913,10 @@ export class PlayerLocal extends Entity {
     const newZoom = clamp(zoomValue, MIN_ZOOM, MAX_ZOOM)
     this.cam.zoom = newZoom
     this.control.camera.zoom = newZoom
+  }
+
+  setZoomEnabled(enabled) {
+    this.zoomEnabled = enabled
   }
 
   setEffect(effect, onEnd) {

--- a/src/core/entities/PlayerLocal.js
+++ b/src/core/entities/PlayerLocal.js
@@ -18,7 +18,7 @@ const SCALE_IDENTITY = new THREE.Vector3(1, 1, 1)
 const POINTER_LOOK_SPEED = 0.1
 const PAN_LOOK_SPEED = 0.4
 const ZOOM_SPEED = 2
-const MIN_ZOOM = 2
+const MIN_ZOOM = 0.5
 const MAX_ZOOM = 100 // 16
 const STICK_MAX_DISTANCE = 50
 const DEFAULT_CAM_HEIGHT = 1.2
@@ -906,6 +906,12 @@ export class PlayerLocal extends Entity {
     if (hasRotation) this.cam.rotation.y = rotationY
     this.control.camera.position.copy(this.cam.position)
     this.control.camera.quaternion.copy(this.cam.quaternion)
+  }
+
+  setZoom(zoomValue) {
+    const newZoom = clamp(zoomValue, MIN_ZOOM, MAX_ZOOM)
+    this.cam.zoom = newZoom
+    this.control.camera.zoom = newZoom
   }
 
   setEffect(effect, onEnd) {

--- a/src/core/extras/createPlayerProxy.js
+++ b/src/core/extras/createPlayerProxy.js
@@ -157,5 +157,10 @@ export function createPlayerProxy(player) {
         player.setZoom(zoomValue)
       }
     },
+    setZoomEnabled(enabled) {
+      if (player.data.owner === world.network.id) {
+        player.setZoomEnabled(enabled)
+      }
+    },
   }
 }

--- a/src/core/extras/createPlayerProxy.js
+++ b/src/core/extras/createPlayerProxy.js
@@ -152,5 +152,10 @@ export function createPlayerProxy(player) {
         world.network.sendTo(player.data.owner, 'playerPush', { force })
       }
     },
+    setZoom(zoomValue) {
+      if (player.data.owner === world.network.id) {
+        player.setZoom(zoomValue)
+      }
+    },
   }
 }


### PR DESCRIPTION
I'm not sure if this will impact scenarios with non player cam but i need it for shooter mechanics and its small.

video:
https://github.com/user-attachments/assets/45b18a88-fca3-4038-8e18-45bb5e4b9997

script:
```js
    // Updated scope functions to handle zoom in and out separately
    const onScopeIn = () => {
      holder.setZoom(0.5); // zoom in (smaller value = more zoom)
      isZoomedIn = true;
    }
  
    const onScopeOut = () => {
      holder.setZoom(2); // zoom out to regular view
      isZoomedIn = false;
    }
```