### PR TITLE
expose base color for Principled BSDF

### DIFF
--- a/docs/ref/Material.md
+++ b/docs/ref/Material.md
@@ -4,6 +4,10 @@ A material on a [Mesh](/docs/ref/Mesh.md) node.
 
 ## Properties
 
+### `.color`: String
+
+The base color of the material. Only available on MeshStandardMaterial (Principled BSDF). Can be set using any valid CSS color string (e.g. "red", "#ff0000", "rgb(255,0,0)").
+
 ### `.textureX`: Number
 
 The offset of the texture on the `x` axis. Useful for UV scrolling.

--- a/src/core/systems/Stage.js
+++ b/src/core/systems/Stage.js
@@ -178,6 +178,22 @@ export class Stage extends System {
         }
         raw.needsUpdate = true
       },
+      get color() {
+        if (!(raw instanceof THREE.MeshStandardMaterial)) {
+          throw new Error('[material] color property only available on MeshStandardMaterial (Principled BSDF)')
+        }
+        return raw.color
+      },
+      set color(val) {
+        if (!(raw instanceof THREE.MeshStandardMaterial)) {
+          throw new Error('[material] color property only available on MeshStandardMaterial (Principled BSDF)')
+        }
+        if (typeof val !== 'string') {
+          throw new Error('[material] color must be a string (e.g. "red", "#ff0000", "rgb(255,0,0)")')
+        }
+        raw.color.set(val)
+        raw.needsUpdate = true
+      },
       get emissiveIntensity() {
         return raw.emissiveIntensity
       },


### PR DESCRIPTION
feat(material): expose base color for Principled BSDF

Add color property to material proxy for modifying MeshStandardMaterial base colors 
via CSS color strings. Includes validation and docs.

Changes:
- src/core/systems/Stage.js: Add color getter/setter to material proxy with validation
- docs/ref/Material.md: Add documentation for color property

Testing:
- Verified working in Chrome and Edge
- Tested with both textured and untextured objects
- Working in Multiplayer

Example usage:
```js
mesh.material.color = 'red';
mesh.material.color = '#00ff00';
mesh.material.color = 'rgb(0, 0, 255)';
```

https://github.com/user-attachments/assets/8a67aa46-8232-437b-aad3-6a47dd84194a

