### PR TITLE
ability to change base color for meshes using apps 

### DIFF
--- a/docs/ref/Material.md
+++ b/docs/ref/Material.md
@@ -12,6 +12,10 @@ The offset of the texture on the `x` axis. Useful for UV scrolling.
 
 The offset of the texture on the `y` axis. Useful for UV scrolling.
 
+### `.color`: String
+
+The base color of the material. Can be set using any valid CSS color string (e.g. "red", "#ff0000", "rgb(255,0,0)").
+
 ### `.emissiveIntensity`: Number
 
 The emissive intensity of the material. Values greater than `1` will activate HDR Bloom, as long as the emissive color is not black.

--- a/src/core/systems/Stage.js
+++ b/src/core/systems/Stage.js
@@ -179,6 +179,16 @@ export class Stage extends System {
         }
         raw.needsUpdate = true
       },
+      get color() {
+        return raw.color
+      },
+      set color(val) {
+        if (typeof val !== 'string') {
+          throw new Error('[material] color must be a string (e.g. "red", "#ff0000", "rgb(255,0,0)")')
+        }
+        raw.color.set(val)
+        raw.needsUpdate = true
+      },
       get emissiveIntensity() {
         return raw.emissiveIntensity
       },


### PR DESCRIPTION
feat(material): expose base color for Principled BSDF

Add color property to material proxy for modifying MeshStandardMaterial base colors
via CSS color strings. Includes validation and docs.

Changes:

src/core/systems/Stage.js: Add color getter/setter to material proxy with validation
docs/ref/Material.md: Add documentation for color property
Testing:

Verified working in Chrome and Edge
Tested with both textured and untextured objects
Working in Multiplayer