### PR TITLE
Make Hyperfy Node-compatible, export minimal necessary core to enable agents

### DIFF
--- a/src/core/createClientWorld.js
+++ b/src/core/createClientWorld.js
@@ -1,11 +1,24 @@
 import { World } from './World'
 
+// Core Systems (Shared)
+import { Settings } from './systems/Settings'
+import { Apps } from './systems/Apps'
+import { Anchors } from './systems/Anchors'
+import { Events } from './systems/Events'
+import { Scripts } from './systems/Scripts'
+import { Chat } from './systems/Chat'
+import { Blueprints } from './systems/Blueprints'
+import { Entities } from './systems/Entities'
+import { Physics } from './systems/Physics'
+import { Stage } from './systems/Stage'
+import { ClientNetwork } from './systems/ClientNetwork'
+
+// Client-Specific Systems
 import { Client } from './systems/Client'
 import { ClientLiveKit } from './systems/ClientLiveKit'
 import { ClientPointer } from './systems/ClientPointer'
 import { ClientPrefs } from './systems/ClientPrefs'
 import { ClientControls } from './systems/ClientControls'
-import { ClientNetwork } from './systems/ClientNetwork'
 import { ClientLoader } from './systems/ClientLoader'
 import { ClientGraphics } from './systems/ClientGraphics'
 import { ClientEnvironment } from './systems/ClientEnvironment'
@@ -22,28 +35,72 @@ import { Snaps } from './systems/Snaps'
 import { Wind } from './systems/Wind'
 import { XR } from './systems/XR'
 
-export function createClientWorld() {
+/**
+ * Creates a World instance tailored for the specified environment.
+ * 
+ * @param {{ env: 'browser' | 'node' }} options - Configuration options.
+ * @returns {World}
+ */
+export function createClientWorld(options = { env: 'browser' }) {
   const world = new World()
-  world.register('client', Client)
-  world.register('livekit', ClientLiveKit)
-  world.register('pointer', ClientPointer)
-  world.register('prefs', ClientPrefs)
-  world.register('controls', ClientControls)
-  world.register('network', ClientNetwork)
-  world.register('loader', ClientLoader)
-  world.register('graphics', ClientGraphics)
-  world.register('environment', ClientEnvironment)
-  world.register('audio', ClientAudio)
-  world.register('stats', ClientStats)
-  world.register('builder', ClientBuilder)
-  world.register('actions', ClientActions)
-  world.register('target', ClientTarget)
-  world.register('ui', ClientUI)
-  world.register('lods', LODs)
-  world.register('nametags', Nametags)
-  world.register('particles', Particles)
-  world.register('snaps', Snaps)
-  world.register('wind', Wind)
-  world.register('xr', XR)
+
+  // Define registration logic reusable for systems
+  function registerSystem(key, SystemClass, proxyHandler = null) {
+    const system = new SystemClass(world)
+    world[key] = proxyHandler ? new Proxy(system, proxyHandler) : system
+    world.systems.push(system) // Push the original system for the update loop
+    return system
+  }
+
+  // --- Register Core Systems (Common to Client & Agent) ---
+  registerSystem('settings', Settings)
+  registerSystem('apps', Apps)
+  registerSystem('anchors', Anchors)
+  registerSystem('events', Events)
+  registerSystem('scripts', Scripts)
+  registerSystem('chat', Chat)
+  registerSystem('blueprints', Blueprints)
+  registerSystem('entities', Entities)
+  registerSystem('physics', Physics) // Requires PhysX loaded in env
+  registerSystem('stage', Stage) // Basic scene graph needed by many systems
+  registerSystem('network', ClientNetwork) // Use ClientNetwork for both
+
+  // --- Register Environment-Specific Systems ---
+  if (options.env !== 'node') {
+    // Client-only systems
+    registerSystem('client', Client)
+    registerSystem('livekit', ClientLiveKit)
+    registerSystem('pointer', ClientPointer)
+    registerSystem('prefs', ClientPrefs)
+    registerSystem('controls', ClientControls)
+    registerSystem('loader', ClientLoader)
+    registerSystem('graphics', ClientGraphics)
+    registerSystem('environment', ClientEnvironment)
+    registerSystem('audio', ClientAudio)
+    registerSystem('stats', ClientStats)
+    registerSystem('builder', ClientBuilder)
+    registerSystem('actions', ClientActions)
+    registerSystem('target', ClientTarget)
+    registerSystem('ui', ClientUI)
+    registerSystem('lods', LODs)
+    registerSystem('nametags', Nametags)
+    registerSystem('particles', Particles)
+    registerSystem('snaps', Snaps)
+    registerSystem('wind', Wind)
+    registerSystem('xr', XR)
+    // ClientPrefs is needed early by ClientAudio, ensure it's registered
+    // world.register('prefs', ClientPrefs) // Already registered above? Let's move it earlier if needed
+
+  } else {
+    // Agent-only or adapted systems
+    // world.register('livekit', AgentLiveKit) // TODO: Create AgentLiveKit or omit
+    registerSystem('prefs', ClientPrefs) // Use ClientPrefs, relying on adapted storage.js
+
+    // Systems NOT needed/adapted for Agent:
+    // Client, ClientPointer, ClientLoader(mostly), ClientGraphics, ClientEnvironment,
+    // ClientAudio, ClientStats, ClientBuilder, ClientActions, ClientTarget, ClientUI,
+    // LODs, Nametags, Particles, Snaps, Wind, XR
+  }
+
   return world
 }

--- a/src/core/entities/PlayerLocal.js
+++ b/src/core/entities/PlayerLocal.js
@@ -46,7 +46,7 @@ export class PlayerLocal extends Entity {
   }
 
   async init() {
-    if (this.world.loader.preloader) {
+    if (this.world.loader?.preloader) {
       await this.world.loader.preloader
     }
 
@@ -160,6 +160,7 @@ export class PlayerLocal extends Entity {
   }
 
   applyAvatar() {
+    if (!this.world.loader) return
     const avatarUrl = this.getAvatarUrl()
     if (this.avatarUrl === avatarUrl) return
     this.world.loader
@@ -276,6 +277,7 @@ export class PlayerLocal extends Entity {
         }
       },
     })
+    if (!this.control.camera) return
     this.control.camera.write = true
     this.control.camera.position.copy(this.cam.position)
     this.control.camera.quaternion.copy(this.cam.quaternion)
@@ -662,7 +664,7 @@ export class PlayerLocal extends Entity {
   }
 
   update(delta) {
-    const isXR = this.world.xr.session
+    const isXR = this.world.xr?.session
     const freeze = this.data.effect?.freeze
     const anchor = this.getAnchorMatrix()
 
@@ -867,7 +869,7 @@ export class PlayerLocal extends Entity {
   }
 
   lateUpdate(delta) {
-    const isXR = this.world.xr.session
+    const isXR = this.world.xr?.session
     const anchor = this.getAnchorMatrix()
     // if we're anchored, force into that pose
     if (anchor) {
@@ -889,11 +891,11 @@ export class PlayerLocal extends Entity {
       const right = v2.crossVectors(forward, UP).normalize()
       this.cam.position.add(right.multiplyScalar(0.3))
     }
-    if (this.world.xr.session) {
+    if (this.world.xr?.session) {
       // in vr snap camera
       this.control.camera.position.copy(this.cam.position)
       this.control.camera.quaternion.copy(this.cam.quaternion)
-    } else {
+    } else if (this.cam && this.control.camera) {
       // otherwise interpolate camera towards target
       simpleCamLerp(this.world, this.control.camera, this.cam, delta)
     }

--- a/src/core/entities/PlayerRemote.js
+++ b/src/core/entities/PlayerRemote.js
@@ -85,6 +85,7 @@ export class PlayerRemote extends Entity {
   }
 
   applyAvatar() {
+    if (!this.world.loader) return
     const avatarUrl = this.data.sessionAvatar || this.data.avatar || 'asset://avatar.vrm'
     if (this.avatarUrl === avatarUrl) return
     this.world.loader.load('avatar', avatarUrl).then(src => {

--- a/src/core/exports.js
+++ b/src/core/exports.js
@@ -1,0 +1,6 @@
+export { createClientWorld } from './createClientWorld.js'
+export { loadPhysX } from '../client/loadPhysX.js' // Use Node version for agent
+export { loadNodePhysX } from './loadNodePhysX.js'
+export { uuid } from './utils.js'
+export { storage } from './storage.js'
+export { System } from './systems/System.js'

--- a/src/core/extras/Layers.js
+++ b/src/core/extras/Layers.js
@@ -24,7 +24,7 @@ function add(group, hits) {
   }
 }
 
-const playerCollision = (process?.env.PUBLIC_PLAYER_COLLISION || env.PUBLIC_PLAYER_COLLISION) === 'true'
+const playerCollision = (process?.env.PUBLIC_PLAYER_COLLISION || (typeof env === 'object' && env.PUBLIC_PLAYER_COLLISION)) === 'true'
 
 add('camera', ['environment'])
 add('player', ['environment', 'prop', playerCollision ? 'player' : null])

--- a/src/core/loadNodePhysX.js
+++ b/src/core/loadNodePhysX.js
@@ -1,0 +1,93 @@
+import path from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
+
+// Path to the PhysX JS binding file relative to this file's built location in 'build/'
+// Adjust if the server PhysX path changes or build structure differs.
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+// Assuming this file will be in build/core/ alongside core.js,
+// and the physx files are copied to build/
+// Resolve directly from the build directory (__dirname)
+const physxJsPath = path.resolve(__dirname, './physx-js-webidl.js')
+
+let promise
+let physxWasmPath // Path to the WASM file
+
+/**
+ * PhysX Loader for Node.js
+ *
+ * Assumes physx-js-webidl.js and physx-js-webidl.wasm have been copied
+ * to the build directory (e.g., by the build script).
+ */
+export function loadNodePhysX() {
+  if (!promise) {
+    promise = new Promise(async (resolve, reject) => {
+      try {
+        // Dynamically import the PhysX JS binding.
+        // This script is expected to define the global `PhysX` factory function.
+        // It might also implicitly load the WASM.
+        // Using file URL for dynamic import is safer in ESM
+        const physxJsFileUrl = pathToFileURL(physxJsPath).href
+        const physxModule = await import(physxJsFileUrl)
+
+        // The PhysX module might export the factory, or put it on globalThis.
+        // The specific build used determines this. Check both.
+        const PhysXFactory = globalThis.PhysX || physxModule.default || physxModule.PhysX
+
+        if (typeof PhysXFactory !== 'function') {
+          throw new Error(
+            'PhysX factory function not found after importing bindings. Check physx-js-webidl.js build settings (EXPORT_NAME, MODULARIZE).'
+          )
+        }
+
+        // Resolve the path to the WASM file relative to the JS binding file
+        // The binding often expects the WASM file to be in the same directory.
+        physxWasmPath = path.resolve(path.dirname(physxJsPath), 'physx-js-webidl.wasm')
+        // console.log("PhysX WASM path:", physxWasmPath); // For debugging
+
+        // The PhysX factory might need configuration, especially the WASM path.
+        // This depends heavily on how the PhysX JS bindings were built.
+        // Common patterns:
+        // 1. Factory finds .wasm automatically if in the same dir (or via default locateFile).
+        // 2. Factory accepts a config object: PhysX({ locateFile: () => physxWasmPath })
+        // 3. Factory needs globalThis.PHYSX_WASM_URL set.
+
+        // Attempt common pattern 1 & 2 (adapt if needed based on PhysX build):
+        let physxInstance
+        try {
+          // Try with locateFile override first
+          physxInstance = await PhysXFactory({
+            locateFile: file => {
+              if (file.endsWith('.wasm')) {
+                // console.log(`Locating WASM: ${physxWasmPath}`); // Debug
+                return physxWasmPath
+              }
+              return file
+            },
+          })
+        } catch (configError) {
+          console.warn('PhysXFactory with config failed, trying without:', configError)
+          // Fallback: Try calling without config (might find WASM automatically)
+          physxInstance = await PhysXFactory()
+        }
+
+        if (!physxInstance || typeof physxInstance.PHYSICS_VERSION === 'undefined') {
+          throw new Error('Failed to initialize PhysX instance.')
+        }
+
+        globalThis.PHYSX = physxInstance // Ensure it's globally available like in the client version
+
+        const version = PHYSX.PHYSICS_VERSION
+        const allocator = new PHYSX.PxDefaultAllocator()
+        const errorCb = new PHYSX.PxDefaultErrorCallback()
+        const foundation = PHYSX.CreateFoundation(version, allocator, errorCb)
+
+        console.log(`Node PhysX ${version} loaded successfully.`)
+        resolve({ version, allocator, errorCb, foundation })
+      } catch (error) {
+        console.error('Error loading Node PhysX:', error)
+        reject(error)
+      }
+    })
+  }
+  return promise
+}

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -1,3 +1,8 @@
+const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
 class LocalStorage {
   get(key, defaultValue = null) {
     const data = localStorage.getItem(key)
@@ -27,10 +32,110 @@ class LocalStorage {
   }
 }
 
-const isBrowser = typeof window !== 'undefined'
+class NodeStorage {
+  isNodeStorage = true; 
+  _cache = null;
+  _storageFilePath = null;
+  _pendingWritePromise = Promise.resolve(); 
+  
+  constructor() { 
+      if (isBrowser) {
+          throw new Error("NodeStorage cannot be constructed in a browser environment.");
+      }
+      this._initializePath(); 
+  }
 
-if (!isBrowser) throw new Error('storage not available on the server')
+  _initializePath() {
+    if (this._storageFilePath) return;
+    try {
+        const dirname = path.dirname(fileURLToPath(import.meta.url));
+        const rootDir = path.join(dirname, '../'); 
+        this._storageFilePath = path.join(rootDir, 'local.json');
+        // console.log(`[NodeStorage _initializePath] Calculated storage path: ${this._storageFilePath}`); 
+    } catch (err) {
+       console.error("Failed to calculate NodeStorage path:", err);
+       this._storageFilePath = null;
+    }
+  }
 
-// TODO: use a MemoryStorage fallback for browser environments that do not allow LocalStorage, eg safari private
+  // Use statically imported fs
+  async _readData() {
+    this._initializePath(); 
+    if (!this._storageFilePath) return {}; 
+    if (this._cache !== null) return this._cache;
+    try {
+      const data = await fs.readFile(this._storageFilePath, 'utf-8'); // Uses imported fs
+      this._cache = JSON.parse(data);
+    } catch (error) {
+       if (error.code === 'ENOENT') { this._cache = {}; }
+       else { console.error(/*...*/); this._cache = {}; }
+    }
+    return this._cache;
+  }
 
-export const storage = new LocalStorage()
+  // Use statically imported fs
+  async _writeData(data) {
+     this._initializePath(); 
+     if (!this._storageFilePath) { /* ... */ return; }
+    try {
+      this._cache = data; 
+      const jsonData = JSON.stringify(data, null, 2);
+      this._pendingWritePromise = this._pendingWritePromise.then(async () => {
+          await fs.writeFile(this._storageFilePath, jsonData); // Uses imported fs
+      }).catch(error => {
+         // ... error handling ...
+      });
+    } catch (error) {
+      // ... error handling ...
+    }
+  }
+
+  async get(key, defaultValue = null) {
+      // Ensure path is calculated before reading
+      this._initializePath(); 
+      const data = await this._readData();
+      return data.hasOwnProperty(key) ? data[key] : defaultValue;
+  }
+
+  async set(key, value) {
+      // Ensure path is calculated before reading for set logic
+      this._initializePath();
+      const data = await this._readData();
+      let changed = false;
+      if (value === undefined || value === null) {
+          if (data.hasOwnProperty(key)) {
+              delete data[key];
+              changed = true;
+          }
+      } else {
+          if (data[key] !== value) {
+              data[key] = value;
+              changed = true;
+          }
+      }
+      if (changed) {
+          this._writeData(data); 
+      }
+  }
+
+  async remove(key) {
+    await this.set(key, null); // Use set(key, null) to handle deletion
+  }
+
+  // Method to await the last pending write
+  async flushWrites() {
+    console.log("[NodeStorage flushWrites] Awaiting pending write operations...");
+    await this._pendingWritePromise;
+    console.log("[NodeStorage flushWrites] Write operations flushed.");
+  }
+}
+
+let storageInstance;
+if (isBrowser) {
+  storageInstance = new LocalStorage();
+} else {
+  // This IIFE resolves immediately with the instance
+  storageInstance = new NodeStorage();
+}
+
+export const storage = storageInstance;

--- a/src/core/systems/ClientControls.js
+++ b/src/core/systems/ClientControls.js
@@ -196,20 +196,22 @@ export class ClientControls extends System {
     this.viewport = viewport
     this.screen.width = this.viewport.offsetWidth
     this.screen.height = this.viewport.offsetHeight
-    window.addEventListener('keydown', this.onKeyDown)
-    window.addEventListener('keyup', this.onKeyUp)
-    document.addEventListener('pointerlockchange', this.onPointerLockChange)
-    this.viewport.addEventListener('pointerdown', this.onPointerDown)
-    window.addEventListener('pointermove', this.onPointerMove)
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', this.onKeyDown)
+      window.addEventListener('keyup', this.onKeyUp)
+      document.addEventListener('pointerlockchange', this.onPointerLockChange)
+      this.viewport.addEventListener('pointerdown', this.onPointerDown)
+      window.addEventListener('pointermove', this.onPointerMove)
     this.viewport.addEventListener('touchstart', this.onTouchStart)
     this.viewport.addEventListener('touchmove', this.onTouchMove)
     this.viewport.addEventListener('touchend', this.onTouchEnd)
     this.viewport.addEventListener('touchcancel', this.onTouchEnd)
     this.viewport.addEventListener('pointerup', this.onPointerUp)
-    this.viewport.addEventListener('wheel', this.onScroll, { passive: false }) // prettier-ignore
-    document.body.addEventListener('contextmenu', this.onContextMenu)
-    window.addEventListener('resize', this.onResize)
-    window.addEventListener('blur', this.onBlur)
+      this.viewport.addEventListener('wheel', this.onScroll, { passive: false }) // prettier-ignore
+      document.body.addEventListener('contextmenu', this.onContextMenu)
+      window.addEventListener('resize', this.onResize)
+      window.addEventListener('blur', this.onBlur)
+    }
   }
 
   bind(options = {}) {


### PR DESCRIPTION
This PR makes changes so Hyperfy is internally node-compatible and can be used to build clients and agents

Everything should work as normal with no issues

Exports build to the /build/core.js which could be packaged to npm