### PR TITLE
feat: add XR controller button support for interactions

### DIFF
--- a/src/core/systems/ClientActions.js
+++ b/src/core/systems/ClientActions.js
@@ -42,7 +42,7 @@ export class ClientActions extends System {
   update(delta) {
     const cameraPos = this.world.rig.position
 
-    this.btnDown = this.control.keyE.down || this.control.touchB.down
+    this.btnDown = this.control.keyE.down || this.control.touchB.down || this.control.xrRightBtn2.down || this.control.xrLeftBtn2.down
 
     // clear current action if its no longer in distance
     if (this.current.node) {


### PR DESCRIPTION
## Description

This PR adds support for XR controller buttons to interact with objects in VR mode. Previously, interactions were only supported via keyboard ('E' key) and mobile touch buttons, but VR controller buttons weren't mapped for the same functionality.

The change extends the input detection in the ClientActions system to recognize both left and right controller buttons (specifically xrLeftBtn2 and xrRightBtn2) when attempting to trigger an interaction with objects in proximity. This allows VR users to have the same interaction capabilities as desktop and mobile users.
The implementation maintains backward compatibility and uses the existing proximity-based interaction system without requiring any changes to existing worlds or components.

Fixes #N/A (Implements enhancement mentioned by core team: "interact button just isn't mapped yet")

## Type of change

- [x] Component enhancement

## How Has This Been Tested?

- [x] Component functionality tests
- [ ] Integration tests with other Hyperfy components
- [ ] World integration testing
- [ ] Cross-browser testing

**Test Configuration**:
* Hyperfy Version: Latest development branch
* Test world setup: Basic world with interactive objects that use Action nodes
* Browser(s): Chrome with WebXR
* Node.js version: 22.13.1

## Checklist:

- [x] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [ ] I have documented the component's usage
- [x] I have tested the component in multiple scenarios
- [x] My changes maintain compatibility with existing worlds
- [x] I have updated the component documentation if needed
