### PR TITLE
App server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,6 @@ CLEAN=true
 LIVEKIT_WS_URL=
 LIVEKIT_API_KEY=
 LIVEKIT_API_SECRET=
+
+# Hooks to connect to a local app dev server
+PUBLIC_DEV_SERVER=false

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ localstorage.json
 node_modules/
 build/
 /world*
-data/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ localstorage.json
 node_modules/
 build/
 /world*
+data/

--- a/docs/App-server.md
+++ b/docs/App-server.md
@@ -1,0 +1,71 @@
+### Prerequisites
+
+- Run your world with client dev features enabled: set env `PUBLIC_DEV_SERVER=true` when starting the client app.
+- You must be an admin in the world to access Dev Tools and link apps.
+
+---
+
+### Start the local app server
+
+```bash
+npx @drama.haus/app-server           # starts on http://localhost:8080 (WS on ws://localhost:8080/)
+```
+
+Notes
+- Hot reload is ON by default. Disable with `--no-hot-reload` or `HOT_RELOAD=false`.
+- Health check: `GET http://localhost:8080/health`.
+
+---
+
+### Link an app from your world (one‑time per app)
+
+1) In your running world, open the Sidebar → Dev Tools (gear icon). It should show Connected if the server is up on port 8080. You can change the port and reconnect from this pane.
+2) Select an app in the Apps pane, open its inspector, and click the Link (chain) icon. The client will:
+   - Create `apps/<appName>/` locally on the dev server if missing
+   - Upload current script and metadata
+   - Save minimal overrides to `apps/<appName>/links.json`
+
+After linking, the app is associated with your world URL and eligible for hot reload.
+
+---
+
+### Common workflow
+
+1) Edit your local file on disk: `apps/<appName>/index.js`.
+2) The dev server detects changes and pushes an update to the connected world only for that linked app.
+3) The client receives the update, hashes and stages the script as `asset://<hash>.js`, uploads it if needed, updates the app blueprint, and applies the changes live.
+
+Result: Changes appear in‑world in ~1–2 seconds without page refresh.
+
+What’s watched by the server
+- `apps/<appName>/index.js` — script changes deploy to the linked world
+- `apps/<appName>/links.json` — blueprint/prop changes deploy to the linked world
+
+Tips
+- You can still use the Dev Tools pane to manually Deploy or Unlink an app.
+- If you add model/prop assets referenced as `asset://<hash>.<ext>`, the server may request the file from the client; assets are saved under `apps/<appName>/assets/`.
+
+---
+
+### Minimal CLI you might use
+
+```bash
+# Start server (hot reload on)
+npx @drama.haus/app-server
+
+# (Optional) Create a scaffold if starting from scratch
+npx @drama.haus/app-server create myApp
+
+# Manually deploy (rarely needed once hot reload is on)
+npx @drama.haus/app-server deploy myApp
+```
+
+---
+
+### Troubleshooting
+
+- Dev Tools shows Disconnected: ensure the server is running and the port matches (default 8080). Use Refresh Status.
+- No Dev Tools in Sidebar: ensure `PUBLIC_DEV_SERVER=true` and you are admin.
+- Changes not appearing: confirm the app is linked (Link icon active) and that you are editing `apps/<appName>/index.js` on the dev server’s filesystem.
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hyperfy",
+  "name": "@drama.haus/hyperfy",
   "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hyperfy",
+      "name": "@drama.haus/hyperfy",
       "version": "0.15.0",
       "license": "GPL-3.0-only",
       "dependencies": {

--- a/src/client/components/DevToolsPane.js
+++ b/src/client/components/DevToolsPane.js
@@ -1,0 +1,720 @@
+import { css } from '@firebolt-dev/css'
+import { useEffect, useRef, useState } from 'react'
+import {
+  CheckCircleIcon,
+  ExternalLinkIcon,
+  LinkIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  SettingsIcon,
+  TrashIcon,
+  UploadIcon,
+  WifiIcon,
+  WifiOffIcon,
+  XCircleIcon,
+  XIcon,
+  SearchIcon,
+} from 'lucide-react'
+import {
+  FieldBtn,
+  FieldText,
+  FieldToggle,
+} from './Fields'
+import { cls } from './cls'
+
+export function DevToolsPane({ world, hidden }) {
+  return (
+    <Pane width='40rem' hidden={hidden}>
+      <div
+        className='devtools'
+        css={css`
+          background: rgba(11, 10, 21, 0.9);
+          border: 1px solid rgba(255, 255, 255, 0.05);
+          border-radius: 1.375rem;
+          display: flex;
+          flex-direction: column;
+          min-height: 17rem;
+          
+          .devtools-head {
+            height: 3.125rem;
+            padding: 0 0.6rem 0 1rem;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+            display: flex;
+            align-items: center;
+          }
+          
+          .devtools-title {
+            flex: 1;
+            font-weight: 500;
+            font-size: 1rem;
+            line-height: 1;
+          }
+          
+          .devtools-status {
+            display: flex;
+            align-items: center;
+            margin-right: 0.5rem;
+          }
+          
+          .devtools-toggle {
+            width: 2rem;
+            height: 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 0 0 1rem;
+            color: #5d6077;
+            &:hover {
+              cursor: pointer;
+            }
+            &.active {
+              color: white;
+            }
+          }
+          
+          .devtools-content {
+            flex: 1;
+            overflow-y: auto;
+          }
+          
+          .apps-list {
+            .app-item {
+              display: flex;
+              align-items: center;
+              padding: 0.75rem 1rem;
+              border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+              
+              &:last-child {
+                border-bottom: none;
+              }
+              
+              &-info {
+                flex: 1;
+                
+                &-name {
+                  font-weight: 500;
+                  margin-bottom: 0.25rem;
+                }
+                
+                &-details {
+                  font-size: 0.8rem;
+                  color: rgba(255, 255, 255, 0.6);
+                }
+              }
+              
+              &-actions {
+                display: flex;
+                gap: 0.5rem;
+              }
+              
+              &-btn {
+                width: 2rem;
+                height: 2rem;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                color: rgba(255, 255, 255, 0.8);
+                &:hover {
+                  cursor: pointer;
+                  color: white;
+                }
+                &.danger {
+                  color: #ff4b4b;
+                  &:hover {
+                    color: #ff6b6b;
+                  }
+                }
+              }
+            }
+          }
+          
+          .empty-state {
+            text-align: center;
+            padding: 2rem 1rem;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 0.9rem;
+          }
+        `}
+      >
+        <div className='devtools-head'>
+          <div className='devtools-title'>Dev Tools</div>
+          <DevToolsStatus world={world} />
+        </div>
+        <div className='devtools-content noscrollbar'>
+          <DevToolsContent world={world} />
+        </div>
+      </div>
+    </Pane>
+  )
+}
+
+function DevToolsStatus({ world }) {
+  const [connectionStatus, setConnectionStatus] = useState('disconnected')
+  const [isConnecting, setIsConnecting] = useState(false)
+  
+  useEffect(() => {
+    checkConnection()
+    
+    // Listen for connection status changes
+    const updateStatus = () => {
+      setConnectionStatus(world.appServerClient.connected ? 'connected' : 'disconnected')
+    }
+    
+    world.appServerClient.on?.('connectionChanged', updateStatus)
+    return () => world.appServerClient.off?.('connectionChanged', updateStatus)
+  }, [])
+
+  const checkConnection = async () => {
+    try {
+      setIsConnecting(true)
+      const devServerUrl = world.appServerClient.url || 'http://localhost:8080'
+      
+      const response = await fetch(`${devServerUrl}/health`)
+      if (response.ok) {
+        setConnectionStatus('connected')
+      } else {
+        setConnectionStatus('error')
+      }
+    } catch (error) {
+      setConnectionStatus('disconnected')
+    } finally {
+      setIsConnecting(false)
+    }
+  }
+
+  const getStatusIcon = () => {
+    if (isConnecting) return <RefreshCwIcon size={16} className={cls('devtools-toggle', 'spin')} />
+    
+    switch (connectionStatus) {
+      case 'connected':
+        return <CheckCircleIcon size={16} style={{ color: '#10b981' }} />
+      case 'disconnected':
+        return <WifiOffIcon size={16} style={{ color: '#6b7280' }} />
+      case 'error':
+        return <XCircleIcon size={16} style={{ color: '#ef4444' }} />
+      default:
+        return <WifiIcon size={16} />
+    }
+  }
+
+  return (
+    <div className='devtools-status'>
+      {getStatusIcon()}
+    </div>
+  )
+}
+
+// Import Pane component
+function Pane({ width = '20rem', hidden, children }) {
+  return (
+    <div
+      className={`sidebarpane ${hidden ? 'hidden' : ''}`}
+      css={css`
+        width: ${width};
+        max-width: 100%;
+        display: flex;
+        flex-direction: column;
+        .sidebarpane-content {
+          pointer-events: auto;
+          max-height: 100%;
+          display: flex;
+          flex-direction: column;
+        }
+        &.hidden {
+          opacity: 0;
+          pointer-events: none;
+        }
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+        
+        .spin {
+          animation: spin 1s linear infinite;
+        }
+      `}
+    >
+      <div className='sidebarpane-content'>{children}</div>
+    </div>
+  )
+}
+
+function Group({ label }) {
+  return (
+    <>
+      <div
+        css={css`
+          height: 0.0625rem;
+          background: rgba(255, 255, 255, 0.05);
+          margin: 0.6rem 0;
+        `}
+      />
+      {label && (
+        <div
+          css={css`
+            font-weight: 500;
+            line-height: 1;
+            padding: 0.75rem 0 0.75rem 1rem;
+            margin-top: -0.6rem;
+          `}
+        >
+          {label}
+        </div>
+      )}
+    </>
+  )
+}
+
+function DevToolsContent({ world }) {
+  const [serverUrl, setServerUrl] = useState('http://localhost:8080')
+  const [customPort, setCustomPort] = useState('8080')
+  const [linkedApps, setLinkedApps] = useState([])
+  const [allApps, setAllApps] = useState([])
+  const [connectionStatus, setConnectionStatus] = useState('disconnected')
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [isLoadingApps, setIsLoadingApps] = useState(false)
+  const [lastError, setLastError] = useState(null)
+  const [lastSuccess, setLastSuccess] = useState(null)
+  const [activeTab, setActiveTab] = useState('linked')
+  const [actionLoading, setActionLoading] = useState({})
+
+  useEffect(() => {
+    // Initialize server URL from AppServerClient if available
+    if (world.appServerClient.url) {
+      setServerUrl(world.appServerClient.url)
+      setCustomPort(world.appServerClient.url.split(':').pop())
+    }
+    
+    // Check initial connection status
+    checkConnection()
+    
+    // Listen for app linked/unlinked events
+    const onAppLinked = ({ appName, linkInfo }) => {
+      loadApps()
+      showSuccess(`${appName} linked successfully`)
+    }
+    const onAppUnlinked = ({ appName }) => {
+      loadApps()
+      showSuccess(`${appName} unlinked successfully`)
+    }
+    
+    world.on('app_linked', onAppLinked)
+    world.on('app_unlinked', onAppUnlinked)
+    
+    return () => {
+      world.off('app_linked', onAppLinked)
+      world.off('app_unlinked', onAppUnlinked)
+    }
+  }, [])
+
+  // Utility functions for showing feedback
+  const showSuccess = (message) => {
+    setLastSuccess(message)
+    setLastError(null)
+    setTimeout(() => setLastSuccess(null), 3000)
+  }
+
+  const showError = (message) => {
+    setLastError(message)
+    setLastSuccess(null)
+  }
+
+  const setActionLoadingState = (action, isLoading) => {
+    setActionLoading(prev => ({ ...prev, [action]: isLoading }))
+  }
+
+  const checkConnection = async () => {
+    try {
+      setIsConnecting(true)
+      setLastError(null)
+      setLastSuccess(null)
+      
+      const response = await fetch(`${serverUrl}/health`)
+      if (response.ok) {
+        setConnectionStatus('connected')
+        showSuccess('Connected to development server')
+        await loadApps()
+      } else {
+        setConnectionStatus('error')
+        showError('Server responded with error')
+      }
+    } catch (error) {
+      setConnectionStatus('disconnected')
+      showError(`Connection failed: ${error.message}`)
+    } finally {
+      setIsConnecting(false)
+    }
+  }
+
+  const disconnect = () => {
+    setConnectionStatus('disconnected')
+    setLinkedApps([])
+    setAllApps([])
+    showSuccess('Disconnected from development server')
+  }
+
+  const loadApps = async () => {
+    try {
+      setIsLoadingApps(true)
+      
+      // Load all apps
+      const allAppsResponse = await fetch(`${serverUrl}/api/apps`)
+      if (allAppsResponse.ok) {
+        const { apps } = await allAppsResponse.json()
+        setAllApps(apps || [])
+      }
+
+      // Load linked apps for current world
+      const worldUrl = world.network?.apiUrl.split("/api")[0]
+      const linkedAppsResponse = await fetch(`${serverUrl}/api/linked-apps?worldUrl=${encodeURIComponent(worldUrl)}`)
+      if (linkedAppsResponse.ok) {
+        const { apps } = await linkedAppsResponse.json()
+        setLinkedApps(apps || [])
+      }
+    } catch (error) {
+      console.warn('Failed to load apps:', error)
+      showError('Failed to load apps list')
+    } finally {
+      setIsLoadingApps(false)
+    }
+  }
+
+  const connectWithCustomPort = async () => {
+    const newUrl = `http://localhost:${customPort}`
+    setServerUrl(newUrl)
+    
+    // Update AppServerClient connection
+    world.appServerClient.setServerUrl(newUrl)
+    
+    await checkConnection()
+  }
+
+  const unlinkApp = async (appName) => {
+    try {
+      setActionLoadingState(`unlink-${appName}`, true)
+      
+      const response = await fetch(`${serverUrl}/api/apps/${appName}/unlink`, {
+        method: 'POST'
+      })
+      
+      if (response.ok) {
+        showSuccess(`${appName} unlinked successfully`)
+        await loadApps()
+      } else {
+        throw new Error('Failed to unlink app')
+      }
+    } catch (error) {
+      console.error(`❌ Failed to unlink ${appName}:`, error)
+      showError(`Failed to unlink ${appName}: ${error.message}`)
+    } finally {
+      setActionLoadingState(`unlink-${appName}`, false)
+    }
+  }
+
+  const pushApp = async (appName) => {
+    try {
+      setActionLoadingState(`push-${appName}`, true)
+      
+      const response = await fetch(`${serverUrl}/api/apps/${appName}/deploy`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          position: [0, 0, 0]
+        })
+      })
+      
+      if (response.ok) {
+        showSuccess(`${appName} deployed successfully`)
+      } else {
+        throw new Error('Failed to deploy app')
+      }
+    } catch (error) {
+      console.error(`❌ Failed to deploy ${appName}:`, error)
+      showError(`Failed to deploy ${appName}: ${error.message}`)
+    } finally {
+      setActionLoadingState(`push-${appName}`, false)
+    }
+  }
+
+  return (
+    <div
+      className='devtools-inner'
+      css={css`
+        padding: 0.5rem 0;
+      `}
+    >
+      <Group label='Connection' />
+      
+      <FieldText
+        label='Server Port'
+        hint={connectionStatus === 'connected' ? 'Disconnect to change port' : 'Port number for the local development server'}
+        value={customPort}
+        onChange={connectionStatus === 'connected' ? () => {} : setCustomPort}
+      />
+      
+      {connectionStatus !== 'connected' && (
+        <FieldBtn
+          label={isConnecting ? 'Connecting...' : 'Connect'}
+          hint='Connect to the development server'
+          onClick={connectWithCustomPort}
+          disabled={isConnecting}
+        />
+      )}
+      
+      {connectionStatus === 'connected' && (
+        <FieldBtn
+          label='Disconnect'
+          hint='Disconnect from the development server'
+          onClick={disconnect}
+          disabled={isConnecting}
+        />
+      )}
+      
+      <FieldBtn
+        label={isConnecting ? 'Checking...' : 'Refresh Status'}
+        hint='Check the current connection status'
+        onClick={checkConnection}
+        disabled={isConnecting}
+      />
+
+      {/* Connection Status Display */}
+      <div
+        css={css`
+          margin: 0.5rem 1rem;
+          padding: 0.75rem 1rem;
+          border-radius: 0.375rem;
+          font-size: 0.9rem;
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          ${connectionStatus === 'connected' && `
+            background: rgba(16, 185, 129, 0.1);
+            border: 1px solid rgba(16, 185, 129, 0.3);
+            color: #a7f3d0;
+          `}
+          ${connectionStatus === 'disconnected' && `
+            background: rgba(156, 163, 175, 0.1);
+            border: 1px solid rgba(156, 163, 175, 0.3);
+            color: #d1d5db;
+          `}
+          ${connectionStatus === 'error' && `
+            background: rgba(239, 68, 68, 0.1);
+            border: 1px solid rgba(239, 68, 68, 0.3);
+            color: #fca5a5;
+          `}
+        `}
+      >
+        {connectionStatus === 'connected' && <CheckCircleIcon size={16} />}
+        {connectionStatus === 'disconnected' && <WifiOffIcon size={16} />}
+        {connectionStatus === 'error' && <XCircleIcon size={16} />}
+        {connectionStatus === 'connected' && `Connected to ${serverUrl}`}
+        {connectionStatus === 'disconnected' && 'Not connected to development server'}
+        {connectionStatus === 'error' && 'Connection error'}
+      </div>
+
+      {/* Success Message */}
+      {lastSuccess && (
+        <div
+          css={css`
+            background: rgba(16, 185, 129, 0.1);
+            border: 1px solid rgba(16, 185, 129, 0.3);
+            border-radius: 0.375rem;
+            padding: 0.75rem 1rem;
+            color: #a7f3d0;
+            font-size: 0.9rem;
+            margin: 0.5rem 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+          `}
+        >
+          <CheckCircleIcon size={16} />
+          {lastSuccess}
+        </div>
+      )}
+
+      {/* Error Message */}
+      {lastError && (
+        <div
+          css={css`
+            background: rgba(239, 68, 68, 0.1);
+            border: 1px solid rgba(239, 68, 68, 0.3);
+            border-radius: 0.375rem;
+            padding: 0.75rem 1rem;
+            color: #fca5a5;
+            font-size: 0.9rem;
+            margin: 0.5rem 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+          `}
+        >
+          <XCircleIcon size={16} />
+          {lastError}
+        </div>
+      )}
+
+      <Group label='Apps' />
+
+      {/* Tab Navigation */}
+      <div
+        css={css`
+          display: flex;
+          border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+          margin: 0 1rem;
+        `}
+      >
+        <div
+          className={`tab ${activeTab === 'linked' ? 'active' : ''}`}
+          onClick={() => setActiveTab('linked')}
+          css={css`
+            padding: 0.75rem 1rem;
+            cursor: pointer;
+            border-bottom: 2px solid transparent;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: all 0.2s ease;
+            
+            &:hover {
+              color: rgba(255, 255, 255, 0.8);
+            }
+            
+            &.active {
+              color: white;
+              border-bottom-color: #10b981;
+            }
+          `}
+        >
+          Linked ({linkedApps.length})
+        </div>
+        <div
+          className={`tab ${activeTab === 'all' ? 'active' : ''}`}
+          onClick={() => setActiveTab('all')}
+          css={css`
+            padding: 0.75rem 1rem;
+            cursor: pointer;
+            border-bottom: 2px solid transparent;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: all 0.2s ease;
+            
+            &:hover {
+              color: rgba(255, 255, 255, 0.8);
+            }
+            
+            &.active {
+              color: white;
+              border-bottom-color: #10b981;
+            }
+          `}
+        >
+          All ({allApps.length})
+        </div>
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === 'linked' && (
+        <>
+          {linkedApps.length === 0 ? (
+            <div className="empty-state">
+              No apps linked yet.<br />
+              Use the link button in app inspectors to connect apps.
+            </div>
+          ) : (
+            <div className="apps-list">
+              {linkedApps.map((app) => (
+                <div key={app.name} className="app-item">
+                  <div className="app-item-info">
+                    <div className="app-item-info-name">{app.name}</div>
+                    <div className="app-item-info-details">
+                      {app.assets.length} assets • {app.script ? 'Has script' : 'No script'}
+                    </div>
+                  </div>
+                  <div className="app-item-actions">
+                    <div 
+                      className={`app-item-btn ${actionLoading[`push-${app.name}`] ? 'loading' : ''}`}
+                      onClick={() => !actionLoading[`push-${app.name}`] && pushApp(app.name)}
+                      title="Deploy local changes to world"
+                      style={{ opacity: actionLoading[`push-${app.name}`] ? 0.5 : 1 }}
+                    >
+                      {actionLoading[`push-${app.name}`] ? (
+                        <RefreshCwIcon size={14} className="spin" />
+                      ) : (
+                        <UploadIcon size={14} />
+                      )}
+                    </div>
+                    <div 
+                      className={`app-item-btn danger ${actionLoading[`unlink-${app.name}`] ? 'loading' : ''}`}
+                      onClick={() => {
+                        if (!actionLoading[`unlink-${app.name}`] && confirm(`Unlink ${app.name}? This will remove the connection but keep the local files.`)) {
+                          unlinkApp(app.name)
+                        }
+                      }}
+                      title="Unlink app from development server"
+                      style={{ opacity: actionLoading[`unlink-${app.name}`] ? 0.5 : 1 }}
+                    >
+                      {actionLoading[`unlink-${app.name}`] ? (
+                        <RefreshCwIcon size={14} className="spin" />
+                      ) : (
+                        <TrashIcon size={14} />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {activeTab === 'all' && (
+        <>
+          {allApps.length === 0 ? (
+            <div className="empty-state">
+              No apps available on development server.<br />
+              Create new apps or download them from the world.
+            </div>
+          ) : (
+            <div className="apps-list">
+              {allApps.map((app) => (
+                <div key={app.name} className="app-item">
+                  <div className="app-item-info">
+                    <div className="app-item-info-name">{app.name}</div>
+                    <div className="app-item-info-details">
+                      {app.assets.length} assets • {app.script ? 'Has script' : 'No script'}
+                    </div>
+                  </div>
+                  <div className="app-item-actions">
+                    <div 
+                      className={`app-item-btn ${actionLoading[`push-${app.name}`] ? 'loading' : ''}`}
+                      onClick={() => !actionLoading[`push-${app.name}`] && pushApp(app.name)}
+                      title="Deploy app to world"
+                      style={{ opacity: actionLoading[`push-${app.name}`] ? 0.5 : 1 }}
+                    >
+                      {actionLoading[`push-${app.name}`] ? (
+                        <RefreshCwIcon size={14} className="spin" />
+                      ) : (
+                        <UploadIcon size={14} />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <Group label='Quick Actions' />
+      
+      <FieldBtn
+        label={isLoadingApps ? 'Refreshing...' : 'Refresh Apps'}
+        hint='Manually refresh the list of apps'
+        onClick={loadApps}
+        disabled={connectionStatus !== 'connected' || isLoadingApps}
+      />
+    </div>
+  )
+} 

--- a/src/client/components/ScriptEditor.js
+++ b/src/client/components/ScriptEditor.js
@@ -142,22 +142,8 @@ export function ScriptEditor({ app, onHandle }) {
               newCode = script.code
             }
           }
-          
-          // Check if editor content has unsaved changes
-          // const currentCode = editor.getValue()
-          // const hasUnsavedChanges = currentCode !== (app.script?.code ?? '// …')
-          
-          // if (hasUnsavedChanges) {
-          //   // Ask user if they want to discard changes
-          //   const shouldDiscard = confirm('The script has been updated externally. Discard your local changes and load the new version?')
-          //   if (!shouldDiscard) return
-          // }
-          
-          // Update the editor with new content
           editor.setValue(newCode)
           codeRef.current = newCode
-          
-          // Clear cached state since we're loading new content
           if (cached.key === key) {
             cached.value = newCode
             cached.viewState = null

--- a/src/client/components/ScriptEditor.js
+++ b/src/client/components/ScriptEditor.js
@@ -118,6 +118,64 @@ export function ScriptEditor({ app, onHandle }) {
       dead = true
     }
   }, [])
+  
+  // Listen for blueprint modifications to update editor content
+  useEffect(() => {
+    if (!editor) return
+    
+    const onBlueprintModify = bp => {
+      // Only update if this is the same blueprint as our current app
+      console.log('debug: blueprint modified', {bp, app})
+      if (bp.id !== app.blueprint.id) return
+      console.log('isSelectedBlueprint')
+      // Load the new script content
+      const loadNewScript = async () => {
+        try {
+          let newCode = '// …'
+          if (bp.script) {
+            // Load the script using the world loader
+            let script = app.world.loader.get('script', bp.script)
+            if (!script) {
+              script = await app.world.loader.load('script', bp.script)
+            }
+            if (script?.code) {
+              newCode = script.code
+            }
+          }
+          
+          // Check if editor content has unsaved changes
+          // const currentCode = editor.getValue()
+          // const hasUnsavedChanges = currentCode !== (app.script?.code ?? '// …')
+          
+          // if (hasUnsavedChanges) {
+          //   // Ask user if they want to discard changes
+          //   const shouldDiscard = confirm('The script has been updated externally. Discard your local changes and load the new version?')
+          //   if (!shouldDiscard) return
+          // }
+          
+          // Update the editor with new content
+          editor.setValue(newCode)
+          codeRef.current = newCode
+          
+          // Clear cached state since we're loading new content
+          if (cached.key === key) {
+            cached.value = newCode
+            cached.viewState = null
+          }
+        } catch (error) {
+          console.error('Failed to load updated script:', error)
+        }
+      }
+      
+      loadNewScript()
+    }
+    
+    app.world.blueprints.on('modify', onBlueprintModify)
+    
+    return () => {
+      app.world.blueprints.off('modify', onBlueprintModify)
+    }
+  }, [editor, app, key])
 
   return (
     <div

--- a/src/core/createClientWorld.js
+++ b/src/core/createClientWorld.js
@@ -21,6 +21,7 @@ import { Particles } from './systems/Particles'
 import { Snaps } from './systems/Snaps'
 import { Wind } from './systems/Wind'
 import { XR } from './systems/XR'
+import { AppServerClient } from './systems/AppServerClient'
 
 export function createClientWorld() {
   const world = new World()
@@ -45,5 +46,6 @@ export function createClientWorld() {
   world.register('snaps', Snaps)
   world.register('wind', Wind)
   world.register('xr', XR)
+  world.register('appServerClient', AppServerClient)
   return world
 }

--- a/src/core/createClientWorld.js
+++ b/src/core/createClientWorld.js
@@ -46,6 +46,6 @@ export function createClientWorld() {
   world.register('snaps', Snaps)
   world.register('wind', Wind)
   world.register('xr', XR)
-  world.register('appServerClient', AppServerClient)
+  if(env.PUBLIC_DEV_SERVER) world.register('appServerClient', AppServerClient)
   return world
 }

--- a/src/core/systems/AppServerClient.js
+++ b/src/core/systems/AppServerClient.js
@@ -1,0 +1,666 @@
+import { storage } from '../storage'
+import { hashFile } from '../utils-client'
+import { System } from './System'
+
+/**
+ * App Server Client System
+ *
+ * - runs on the client
+ * - handles connection and communication with local development app server
+ * - manages app deployment, hot reloading, and linking functionality
+ *
+ */
+export class AppServerClient extends System {
+  static FILE_TYPES = {
+    glb: { mimeType: 'model/gltf-binary', loaderType: 'model' },
+    vrm: { mimeType: 'model/gltf-binary', loaderType: 'avatar' },
+    jpg: { mimeType: 'image/jpeg', loaderType: 'image' },
+    jpeg: { mimeType: 'image/jpeg', loaderType: 'image' },
+    png: { mimeType: 'image/png', loaderType: 'image' },
+    gif: { mimeType: 'image/gif', loaderType: 'image' }
+  }
+  constructor(world) {
+    super(world)
+    this.ws = null
+    this.url = null
+    this.connected = false
+  }
+
+  init() {
+    this.world.on('ready', () => {
+      console.log("isAdmin", this.world.entities.player?.isAdmin())
+      if (
+        !(env.PUBLIC_DEV_SERVER === 'true') || 
+        !this.world.entities.player?.isAdmin()
+      ) return
+
+      this.setServerUrl("http://localhost:8080")
+      this.worldUrl = this.world.network.apiUrl.split("/api")[0]
+
+      this.world.blueprints.on("modify", async (blueprint) => {
+
+        // Only send blueprint modifications for linked apps
+        const isLinked = await this.isLinked(blueprint.id)
+        if (isLinked) {
+          // TODO: debounce instead of setTimeout
+          setTimeout(() => {
+            this.send({
+              type: 'blueprint_modified',
+              blueprint: blueprint
+            })
+          }, 500)
+        } else {
+        }
+      })
+    })
+  }
+
+  setServerUrl(url) {
+    // Check if dev server feature is enabled
+    console.log('[AppServerClient] Checking if dev server is enabled:', env.PUBLIC_DEV_SERVER)
+    const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
+    if (!isDevServerEnabled) {
+      console.log('[AppServerClient] Dev server feature is disabled, aborting setServerUrl')
+      return
+    }
+
+    console.log('[AppServerClient] Setting server URL:', url)
+    const isWebSocket = url.startsWith('ws')
+    console.log('[AppServerClient] isWebSocket:', isWebSocket)
+    this.wsUrl = isWebSocket ? url : url.replace(/^https?:/, url.startsWith('https') ? 'wss:' : 'ws:')
+    this.url = isWebSocket ? url.replace(/^wss?:/, url.startsWith('wss') ? 'https:' : 'http:') : url
+    console.log('[AppServerClient] wsUrl set to:', this.wsUrl)
+    console.log('[AppServerClient] url set to:', this.url)
+    this.connect()
+  }
+
+  connect() {
+    if (!this.wsUrl) return
+
+
+    this.ws = new WebSocket(this.wsUrl)
+
+    const events = { open: this.onOpen, message: this.onMessage, close: this.onClose, error: this.onError }
+    Object.entries(events).forEach(([event, handler]) => this.ws.addEventListener(event, handler))
+  }
+
+  onOpen = () => {
+    this.connected = true
+
+    console.log('[AppServerClient] Connected to app server')
+    
+
+    // Authenticate with app server
+    this.send({
+      type: 'auth',
+      userId: this.world.network?.id || 'anonymous',
+      authToken: storage.get('authToken'),
+      worldUrl: this.worldUrl
+    })
+  }
+
+  onMessage = async (e) => {
+    try {
+      const message = JSON.parse(e.data)
+
+      switch (message.type) {
+        case 'auth_success':
+          console.log('✅ Authenticated with app server')
+          break
+
+        case 'deploy_app':
+          this.handleDeployApp(message.app)
+          break
+
+        case 'app_linked':
+          this.world.emit('app_linked', { appName: message.appName, linkInfo: message.linkInfo })
+          break
+
+        case 'app_unlinked':
+          this.world.emit('app_unlinked', { appName: message.appName })
+          break
+
+        case 'request_asset':
+          await this.handleAssetRequest(message)
+          break
+
+        case 'request_blueprint':
+          await this.handleBlueprintRequest(message)
+          break
+
+
+        default:
+      }
+    } catch (err) {
+      console.error('❌ Error parsing app server message:', err)
+    }
+  }
+
+  onClose = () => {
+    this.connected = false
+  }
+
+  onError = (err) => {
+    console.error('🔥 App server error:', err)
+  }
+
+  send(message) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      console.log('🔥 Sending message:', message)
+      this.ws.send(JSON.stringify(message))
+    } else {
+      console.warn('⚠️  App server not connected, cannot send message')
+    }
+  }
+
+
+
+  async processScriptContent(scriptContent) {
+    if (!scriptContent) return scriptContent
+    // Convert script content to file and process like ScriptEditor save function
+    const blob = new Blob([scriptContent], { type: 'text/plain' })
+    const file = new File([blob], 'script.js', { type: 'text/plain' })
+
+    // Hash the file to get unique filename
+    const hash = await hashFile(file)
+    const filename = `${hash}.js`
+
+    // Create canonical URL
+    const url = `asset://${filename}`
+
+    // Cache file locally so this client can load it
+    this.world.loader.insert('script', url, file)
+
+    // Upload script to server
+    if (this.world.network) {
+      await this.world.network.upload(file)
+    }
+
+    return url
+  }
+
+  async processModelContent(assetUrl, assetType = 'model') {
+    // If already a valid asset URL and file is cached, ensure it's uploaded
+    if (assetUrl && assetUrl.startsWith('asset://')) {
+
+      // Check if we already have this file cached locally
+      const cachedFile = this.world.loader.getFile(assetUrl)
+      if (cachedFile) {
+        // Upload to server if network available
+        if (this.world.network) {
+          await this.world.network.upload(cachedFile)
+        }
+        return assetUrl
+      } else {
+        // File not cached - request it from dev server
+        try {
+          const assetContent = await this.requestModelContentFromServer(assetUrl)
+          if (assetContent) {
+            // Convert base64 content to file
+            const buffer = Uint8Array.from(atob(assetContent), c => c.charCodeAt(0))
+            const blob = new Blob([buffer])
+            const filename = assetUrl.replace('asset://', '')
+
+            // Determine file type based on extension and asset type
+            const ext = filename.split('.').pop()?.toLowerCase()
+            const fileType = AppServerClient.FILE_TYPES[ext] || { mimeType: 'application/octet-stream', loaderType: assetType }
+            const { mimeType, loaderType } = fileType
+
+            const file = new File([blob], filename, { type: mimeType })
+
+            // Cache file locally
+            this.world.loader.insert(loaderType, assetUrl, file)
+
+            // Upload to server
+            if (this.world.network) {
+              await this.world.network.upload(file)
+            }
+
+            return assetUrl
+          }
+        } catch (error) {
+          console.warn(`⚠️  Failed to get ${assetType} content from server:`, error.message)
+          return assetUrl
+        }
+      }
+    }
+
+    return assetUrl
+  }
+
+  async requestModelContentFromServer(modelUrl) {
+    return new Promise((resolve, reject) => {
+      const requestId = `model_request_${Date.now()}_${Math.random()}`
+      const timeout = setTimeout(() => {
+        reject(new Error('Model request timeout'))
+      }, 10000) // 10 second timeout
+
+      // Set up response handler
+      const handleResponse = (message) => {
+        if (message.type === 'model_content_response' && message.requestId === requestId) {
+          clearTimeout(timeout)
+          this.ws.removeEventListener('message', handleResponse)
+
+          if (message.success) {
+            resolve(message.content)
+          } else {
+            reject(new Error(message.error || 'Failed to get model content'))
+          }
+        }
+      }
+
+      this.ws.addEventListener('message', (event) => {
+        try {
+          const data = JSON.parse(event.data)
+          handleResponse(data)
+        } catch (err) {
+          // Ignore invalid JSON
+        }
+      })
+
+      // Send request to dev server
+      this.send({
+        type: 'request_model_content',
+        requestId: requestId,
+        modelUrl: modelUrl
+      })
+    })
+  }
+
+  async processPropsFiles(props) {
+    if (!props || typeof props !== 'object') {
+      return props
+    }
+
+    const processedProps = {}
+
+    for (const [key, value] of Object.entries(props)) {
+      if (value && typeof value === 'object') {
+        // Check if this is a file object with url property
+        if (value.url && typeof value.url === 'string' && value.url.startsWith('asset://')) {
+          // This is a file prop that needs processing
+          const fileType = value.type || 'unknown'
+
+          try {
+            // Process the file URL (upload to server if needed)
+            let processedUrl = value.url
+            const knownTypes = ['model', 'avatar', 'emote', 'texture', 'image', 'hdr', 'audio']
+            if (knownTypes.includes(fileType)) {
+              processedUrl = await this.processModelContent(value.url, fileType)
+            } else {
+              const cachedFile = this.world.loader.getFile(value.url)
+              if (cachedFile && this.world.network) {
+                await this.world.network.upload(cachedFile)
+              }
+            }
+
+            processedProps[key] = {
+              ...value,
+              url: processedUrl
+            }
+          } catch (error) {
+            console.warn(`   ⚠️  Failed to process ${fileType} file in prop '${key}':`, error.message)
+            processedProps[key] = value // Use original value as fallback
+          }
+        } else if (Array.isArray(value)) {
+          processedProps[key] = await Promise.all(value.map(item => this.processPropsFiles(item)))
+        } else if (typeof value === 'object') {
+          processedProps[key] = await this.processPropsFiles(value)
+        } else {
+          processedProps[key] = value
+        }
+      } else {
+        processedProps[key] = value
+      }
+    }
+
+    return processedProps
+  }
+
+  async handleDeployApp(appData) {
+    const isUpdate = appData.isUpdate || this.world.blueprints.get(appData.id)
+
+    if (isUpdate) {
+      await this.handleAppUpdate(appData)
+    } else {
+      await this.handleNewAppDeployment(appData)
+    }
+  }
+
+  async handleNewAppDeployment(appData) {
+
+    // Process all assets concurrently
+    const { scriptUrl, modelUrl, processedProps } = await this.processAppAssets(appData)
+
+    // Create blueprint and entity data
+    const blueprint = this.createBlueprint(appData, scriptUrl, modelUrl, processedProps)
+    const entityData = this.createEntityData(appData)
+
+    // Add blueprint and entity locally
+    this.world.blueprints.add(blueprint, true)
+    this.world.entities.add(entityData, true)
+
+    this.world.network.send('blueprintAdded', blueprint)
+    this.world.network.send('entityAdded', entityData)
+
+    // Auto-link this freshly deployed app to the dev server
+    try {
+      const appEntity = this.world.entities.get(entityData.id)
+      if (appEntity) {
+        await this.linkToDevServer(appEntity)
+      }
+    } catch (err) {
+      console.warn('⚠️  Auto-linking failed:', err?.message || err)
+    }
+    
+  }
+
+  async handleAppUpdate(appData) {
+
+    // Get the existing blueprint
+    const blueprint = this.world.blueprints.get(appData.id)
+    if (!blueprint) {
+      console.warn(`⚠️  Blueprint ${appData.id} not found`)
+      return
+    }
+
+    // Process all assets concurrently
+    const { scriptUrl, modelUrl, processedProps } = await this.processAppAssets(appData, blueprint)
+
+    // Create updated blueprint
+    const updatedBlueprint = this.createBlueprint(appData, scriptUrl, modelUrl, processedProps, blueprint)
+
+
+    // Update locally first
+    this.world.blueprints.modify(updatedBlueprint)
+
+    // Send to main server via network system
+    if (this.world.network) {
+      this.world.network.send('blueprintModified', updatedBlueprint)
+    }
+
+  }
+
+  async handleAssetRequest(message) {
+    const { requestId, assetUrl, assetType } = message
+
+    try {
+      let content = null
+
+      const file = this.world.loader.getFile(assetUrl)
+
+      if (!file) {
+        throw new Error(`Asset not found: ${assetUrl}`)
+      }
+
+      if (assetType === 'script') {
+        content = await file.text()
+      } else {
+        content = await this.fileToBase64(file)
+      }
+
+
+      // Send response back to dev server
+      this.send({
+        type: 'asset_response',
+        requestId: requestId,
+        success: !!content,
+        content: content,
+        error: content ? null : `Asset not found: ${assetUrl}`
+      })
+
+    } catch (error) {
+      console.error(`❌ Error handling asset request:`, error)
+      this.send({
+        type: 'asset_response',
+        requestId: requestId,
+        success: false,
+        content: null,
+        error: error.message
+      })
+    }
+  }
+
+  async fileToBase64(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        // Remove the data URL prefix (e.g., "data:image/png;base64,")
+        const base64 = reader.result.split(',')[1]
+        resolve(base64)
+      }
+      reader.onerror = reject
+      reader.readAsDataURL(file)
+    })
+  }
+
+  async handleBlueprintRequest(message) {
+    const { requestId, blueprintId, appName } = message
+    
+    try {
+      // Find the blueprint by ID
+      const blueprint = this.world.blueprints.get(blueprintId)
+      
+      if (!blueprint) {
+        throw new Error(`Blueprint not found: ${blueprintId}`)
+      }
+      
+      console.log(`📤 Sending blueprint data for ${appName} (${blueprintId})`)
+      
+      // Send response back to dev server
+      this.send({
+        type: 'blueprint_response',
+        requestId: requestId,
+        success: true,
+        blueprint: blueprint,
+        error: null
+      })
+      
+    } catch (error) {
+      console.error(`❌ Error handling blueprint request for ${appName}:`, error)
+      this.send({
+        type: 'blueprint_response',
+        requestId: requestId,
+        success: false,
+        blueprint: null,
+        error: error.message
+      })
+    }
+  }
+
+  destroy() {
+    if (this.ws) {
+      const events = { open: this.onOpen, message: this.onMessage, close: this.onClose, error: this.onError }
+      Object.entries(events).forEach(([event, handler]) => this.ws.removeEventListener(event, handler))
+
+      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
+        this.ws.close()
+      }
+      this.ws = null
+    }
+
+    this.connected = false
+  }
+
+  /**
+   * Link an app to the development server
+   * @param {Object} app - The app entity
+   * @param {Object} blueprint - The app blueprint
+   * @returns {Promise<boolean>} - Success status
+   */
+  async linkToDevServer(app) {
+    // Check if dev server feature is enabled
+    const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
+    if (!isDevServerEnabled) {
+      throw new Error('Dev server feature is disabled')
+    }
+
+    try {
+      const { blueprint } = app
+      let devServerApp = await fetch(`${this.url}/api/apps/${blueprint.name}`).then(res => res.json()).then(data => data.app)
+
+      if (!devServerApp) {
+        await this.uploadToDevServer(app)
+        devServerApp = await fetch(`${this.url}/api/apps/${blueprint.name}`).then(res => res.json()).then(data => data.app)
+      }
+
+      await this.linkApps(devServerApp, app)
+
+
+      return true
+
+    } catch (error) {
+      console.error(`❌ Failed to link ${blueprint.name}:`, error.message)
+      throw error
+    }
+  }
+
+  /**
+   * Download and create an app on the development server
+   * @param {Object} app - The app entity
+   * @param {Object} blueprint - The app blueprint
+   */
+  async uploadToDevServer(app) {
+    const { blueprint } = app
+    // Create app data in development server format
+    const { id, version, ...appData } = blueprint
+
+    // Include script content if available
+    if (blueprint.script) {
+      appData.script = app.script.code
+    }
+
+    // Create the app on development server
+    await this.apiRequest(`/api/apps/${blueprint.name}`, {
+      method: 'POST',
+      body: JSON.stringify(appData)
+    })
+  }
+
+  /**
+   * TODO: what if their contents are different?
+   * Link an existing app on the development server
+   * @param {Object} devServerApp - The existing app on the dev server
+   * @param {Object} app - The app entity
+   * @param {Object} blueprint - The app blueprint
+   */
+  async linkApps(devServerApp, app) {
+    const { blueprint } = app
+    // Create link info
+    const linkInfo = {
+      worldUrl: this.worldUrl,
+      blueprint,
+      appName: blueprint.name,
+      assetsUrl: this.world.assetsUrl,
+      linkedAt: new Date().toISOString()
+    }
+
+    // Send link command to development server  
+    await this.apiRequest(`/api/apps/${devServerApp.name}/link`, {
+      method: 'POST',
+      body: JSON.stringify({ linkInfo })
+    })
+  }
+
+  /**
+   * Unlink an app from the development server
+   * @param {string} appName - The name of the app to unlink
+   * @returns {Promise<boolean>} - Success status
+   */
+  async unlinkApps(appName) {
+    // Check if dev server feature is enabled
+    const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
+    if (!isDevServerEnabled) {
+      throw new Error('Dev server feature is disabled')
+    }
+
+    try {
+
+      await this.apiRequest(`/api/apps/${appName}/unlink`, {
+        method: 'POST'
+      })
+
+      return true
+
+    } catch (error) {
+      console.error(`❌ Failed to unlink ${appName}:`, error.message)
+      throw error
+    }
+  }
+
+  /**
+   * Check if a blueprint is linked to the development server
+   * @param {string} blueprintId - The blueprint ID to check
+   * @returns {Promise<boolean>} - Whether the blueprint is linked
+   */
+  async isLinked(blueprintId) {
+    try {
+      // Check if dev server feature is enabled
+      const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
+      if (!isDevServerEnabled) {
+        return false
+      }
+
+      if (!this.connected || !this.url) {
+        return false
+      }
+
+      const worldUrl = this.worldUrl
+      const response = await fetch(`${this.url}/api/apps/is-linked?blueprintId=${encodeURIComponent(blueprintId)}&worldUrl=${encodeURIComponent(worldUrl)}`)
+
+      if (!response.ok) {
+        console.warn('⚠️  Failed to check blueprint link status')
+        return false
+      }
+
+      const data = await response.json()
+      return data.success && data.isLinked
+    } catch (error) {
+      console.warn('⚠️  Error checking blueprint link:', error.message)
+      return false
+    }
+  }
+
+  async processAppAssets(appData, blueprint = {}) {
+    const [scriptUrl, modelUrl, processedProps] = await Promise.all([
+      this.processScriptContent(appData.script),
+      this.processModelContent(appData.model),
+      this.processPropsFiles(appData.props || blueprint.props || {})
+    ])
+    return { scriptUrl, modelUrl, processedProps }
+  }
+
+  // Helper for API requests
+  async apiRequest(endpoint, options = {}) {
+    const response = await fetch(`${this.url}${endpoint}`, {
+      headers: { 'Content-Type': 'application/json' },
+      ...options
+    })
+    if (!response.ok) throw new Error(`API request failed: ${endpoint}`)
+    return response
+  }
+
+  // Helper for blueprint creation
+  createBlueprint(appData, scriptUrl, modelUrl, processedProps, existingBlueprint = null) {
+    return {
+      id: appData.id,
+      version: existingBlueprint ? existingBlueprint.version + 1 : 1,
+      name: appData.name || existingBlueprint?.name,
+      script: scriptUrl,
+      model: modelUrl,
+      props: processedProps
+    }
+  }
+
+  createEntityData(appData) {
+    return {
+      id: appData.id,
+      type: 'app',
+      blueprint: appData.id,
+      position: appData.position || [0, 0, 0],
+      quaternion: [0, 0, 0, 1],
+      scale: [1, 1, 1],
+      state: {}
+    }
+  }
+} 

--- a/src/core/systems/AppServerClient.js
+++ b/src/core/systems/AppServerClient.js
@@ -28,11 +28,7 @@ export class AppServerClient extends System {
 
   init() {
     this.world.on('ready', () => {
-      console.log("isAdmin", this.world.entities.player?.isAdmin())
-      if (
-        !(env.PUBLIC_DEV_SERVER === 'true') || 
-        !this.world.entities.player?.isAdmin()
-      ) return
+      if (!this.world.entities.player?.isAdmin()) return
 
       this.setServerUrl("http://localhost:8080")
       this.worldUrl = this.world.network.apiUrl.split("/api")[0]
@@ -56,14 +52,6 @@ export class AppServerClient extends System {
   }
 
   setServerUrl(url) {
-    // Check if dev server feature is enabled
-    console.log('[AppServerClient] Checking if dev server is enabled:', env.PUBLIC_DEV_SERVER)
-    const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
-    if (!isDevServerEnabled) {
-      console.log('[AppServerClient] Dev server feature is disabled, aborting setServerUrl')
-      return
-    }
-
     console.log('[AppServerClient] Setting server URL:', url)
     const isWebSocket = url.startsWith('ws')
     console.log('[AppServerClient] isWebSocket:', isWebSocket)
@@ -489,12 +477,6 @@ export class AppServerClient extends System {
    * @returns {Promise<boolean>} - Success status
    */
   async linkToDevServer(app) {
-    // Check if dev server feature is enabled
-    const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
-    if (!isDevServerEnabled) {
-      throw new Error('Dev server feature is disabled')
-    }
-
     try {
       const { blueprint } = app
       let devServerApp = await fetch(`${this.url}/api/apps/${blueprint.name}`).then(res => res.json()).then(data => data.app)
@@ -568,12 +550,6 @@ export class AppServerClient extends System {
    * @returns {Promise<boolean>} - Success status
    */
   async unlinkApps(appName) {
-    // Check if dev server feature is enabled
-    const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
-    if (!isDevServerEnabled) {
-      throw new Error('Dev server feature is disabled')
-    }
-
     try {
 
       await this.apiRequest(`/api/apps/${appName}/unlink`, {
@@ -595,12 +571,6 @@ export class AppServerClient extends System {
    */
   async isLinked(blueprintId) {
     try {
-      // Check if dev server feature is enabled
-      const isDevServerEnabled = env.PUBLIC_DEV_SERVER === 'true'
-      if (!isDevServerEnabled) {
-        return false
-      }
-
       if (!this.connected || !this.url) {
         return false
       }

--- a/src/core/systems/ClientLoader.js
+++ b/src/core/systems/ClientLoader.js
@@ -89,10 +89,7 @@ export class ClientLoader extends System {
     const remoteUrl = this.world.resolveURL(url)
     const file = this.files.get(remoteUrl) ?? this.files.get(url)
     if (!file) return null
-    if(this.files.has(url) && this.files.has(remoteUrl)) {
-      console.log('debug: delete cache', remoteUrl)
-      this.files.delete(url)
-    }
+    if(this.files.has(url) && this.files.has(remoteUrl)) this.files.delete(url) // delete `file://` entry
     return name ? 
       new File([file], name, {
         type: file.type, // Preserve the MIME type
@@ -248,14 +245,7 @@ export class ClientLoader extends System {
   insert(type, url, file) {
     const key = `${type}/${url}`
     const localUrl = URL.createObjectURL(file)
-
-    // Store the file immediately for quick access
-    console.log('debug: insert', { url, file })
-    console.log(this.files)
     this.files.set(url, file)
-    console.log('debug: inserted')
-    console.log(this.files)
-
     let promise
     if (type === 'hdr') {
       promise = this.rgbeLoader.loadAsync(localUrl).then(texture => {


### PR DESCRIPTION
App server 

as per https://github.com/hyperfy-xyz/hyperfy/issues/110#issuecomment-3105162968:

>- devs can git clone a hyperfy "app server" or run something like npx hyperfy-app-server to generate a project
>- inside that project they run npm run start to launch the app server
>- now, inside ANY hyperfy world (localhost or even live domain) your browser will realise there is an app server running locally (automatically) and show a "local sync" button on the app (see img below)
>- clicking this button will send the entire hyp to the app server, which then spawns a folder for the app with all the assets in it
>- changing any of the files pushes it back to the world and it updates
>In the other direction, in the world when you click the + button to add an app, if you have an app server running it will also list those local apps there too, and when you add them to the world they will automatically be synced locally.

---

my proposal is to have a `PUBLIC_DEV_SERVER` flag that, when active, adds a new system to the client that attempts a connection with an app server on `localhost:8080` (port can be changed). this system:
- checks if any apps are linked
- handles receiving updates for linked apps
- sends app updates to the app server
- sends requests for deployment of new apps
- sends assets to the app server

the app server itself is a small class that anyone can hook up handlers in order to create their own custom functionality for their use case (typescript? code splitting?). if we run `node tools/server.js` (which we should hook up to `npx hyperfy app-server` imo) it runs a basic server with hot reloading.

---

the idea of separating a thin server from the handlers enables people to build their own custom servers which could include code splitting, typescript, anything they need. 

keeping the app server totally separate from the client but still requiring the auth token enables apps with custom deploy pipelines (with the node client) but still tied to a specific user (which might be handy if we ever add audit changes ("last change by: peezy")

---

what needs to be agreed upon for merging:
- [ ]  do we keep this sample server on hyperfy codebase? 
    - the benefit is that people devving on local worlds wouldnt need to set anything else up. 
    - the con is that it might incentivize people to commit their apps code with the engine code. this might not be ideal
 - [ ] if we go down this route, we should probably make a `vibe coding starter kit` repository with a server, some docs on scripting and instructions for claude code

