### PR TITLE
Update Prim.md

### DIFF
--- a/docs/scripting/nodes/types/Prim.md
+++ b/docs/scripting/nodes/types/Prim.md
@@ -2,6 +2,8 @@
 
 Creates primitive 3D shapes with built-in geometry caching for optimal performance.
 
+Primitives origins are the in the middle of their shapes.
+
 ## Properties
 
 ### `.type`: String


### PR DESCRIPTION
Note that origins are in the middle of their shapes

It seems to matter mostly for relative spacing, like if I'm working on an obstacle course in sections, and i make a debugger to space different sections, if it doesn't have the context of the origins it will be shifted a bit outside of the section on one end.

I think you are also seeing these implications when people prompt complex objects in discord.
