### PR TITLE
ClientControls to accept callbacks for the initial user interaction

### DIFF
--- a/src/core/systems/ClientControls.js
+++ b/src/core/systems/ClientControls.js
@@ -85,6 +85,9 @@ export class ClientControls extends System {
       delta: 0,
     }
     this.xrSession = null
+
+    this.pointerLockOccurred = false
+    document.addEventListener('pointerlockchange', () => this.pointerLockOccurred = true, { once: true })
   }
 
   start() {
@@ -546,6 +549,15 @@ export class ClientControls extends System {
           button.onRelease?.()
         }
       }
+    }
+  }
+
+  onInitialPointerLock(callback) {
+    if (this.pointerLockOccurred) {
+      callback.call()
+
+    } else {
+      document.addEventListener('pointerlockchange', callback, { once: true })
     }
   }
 

--- a/src/core/systems/ClientControls.js
+++ b/src/core/systems/ClientControls.js
@@ -86,8 +86,8 @@ export class ClientControls extends System {
     }
     this.xrSession = null
 
-    this.pointerLockOccurred = false
-    document.addEventListener('pointerlockchange', () => this.pointerLockOccurred = true, { once: true })
+    this.pointerInteractionOccurred = false
+    document.addEventListener('pointerdown', () => this.pointerInteractionOccurred = true, { once: true })
   }
 
   start() {
@@ -552,12 +552,12 @@ export class ClientControls extends System {
     }
   }
 
-  onInitialPointerLock(callback) {
-    if (this.pointerLockOccurred) {
+  onInitialPointerInteraction(callback) {
+    if (this.pointerInteractionOccurred) {
       callback.call()
 
     } else {
-      document.addEventListener('pointerlockchange', callback, { once: true })
+      document.addEventListener('pointerdown', callback, { once: true })
     }
   }
 


### PR DESCRIPTION
## Description

Adds the detection of the initial pointer-lock from the user.

To be used e.g. this way:

```
world['controls'].onInitialPointerLock(() => console.log('initial pointer lock detected'))
```

## Type of change

- [x] Component enhancement

## How Has This Been Tested?

- [x] Component functionality tests
- [x] Integration tests with other Hyperfy components
- [x] World integration testing
- [ ] Cross-browser testing

**Test Configuration**:
* Hyperfy Version: latest
* Test world setup: simple
* Browser(s): Firefox
* Node.js version: 22.11.0

## Checklist:

- [x] My code follows Hyperfy's component architecture
- [x] I have performed a self-review
- [ ] I have documented the component's usage
- [x] I have tested the component in multiple scenarios
- [x] My changes maintain compatibility with existing worlds
- [ ] I have updated the component documentation if needed
