### PR TITLE
chore: add dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      fastify:
+        patterns:
+          - "fastify"
+          - "@fastify/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+      livekit:
+        patterns:
+          - "livekit-*"
+      firebolt:
+        patterns:
+          - "@firebolt-dev/*"
+      three:
+        patterns:
+          - "three"
+          - "three-mesh-bvh"
+          - "@pixiv/three-vrm"
+      lint-tooling:
+        patterns:
+          - "eslint*"
+          - "prettier"
+          - "@babel/*"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(actions)"


### PR DESCRIPTION
Adds dependabot config for automated dependency maintenance.

**What it does**
- Targets `dev` branch (matches our merge flow)
- Covers `npm` + `github-actions` ecosystems
- Weekly schedule on Mondays
- Groups related packages to reduce PR noise: `fastify`, `react`, `livekit`, `@firebolt-dev/*`, `three` family, lint tooling (eslint/prettier/babel), plus a `minor-and-patch` catchall for everything else

**Supply chain hardening**
- `cooldown.default-days: 7` — waits a week before pulling new releases. Mitigates the "publish malicious version → CI auto-merges before npm catches it" pattern. Security advisories bypass cooldown so real vuln fixes still come fast.
- `cooldown.semver-major-days: 14` — extra scrutiny window for major bumps.